### PR TITLE
consensus-preprocess.pl: Use #!/usr/bin/env perl

### DIFF
--- a/consensus-preprocess.pl
+++ b/consensus-preprocess.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 #
 # Extract fast5 file names from a poretools fasta file and prepend an index to uniquify names
 #


### PR DESCRIPTION
Use #!/usr/bin/env perl to search the PATH for perl
rather than hardcoding #!/usr/bin/perl.