### PR TITLE
Model stdv

### DIFF
--- a/src/alignment/nanopolish_eventalign.cpp
+++ b/src/alignment/nanopolish_eventalign.cpp
@@ -57,6 +57,7 @@ static const char *EVENTALIGN_USAGE_MESSAGE =
 "      --progress                       print out a progress message\n"
 "  -n, --print-read-names               print read names instead of indexes\n"
 "  -f, --full                           print event stdv, and model sd_ parameters\n"
+"      --stdv                           enable stdv modelling\n"
 "\nReport bugs to " PACKAGE_BUGREPORT "\n\n";
 
 namespace opt
@@ -75,7 +76,7 @@ namespace opt
 
 static const char* shortopts = "r:b:g:t:w:vnf";
 
-enum { OPT_HELP = 1, OPT_VERSION, OPT_PROGRESS };
+enum { OPT_HELP = 1, OPT_VERSION, OPT_PROGRESS, OPT_STDV };
 
 static const struct option longopts[] = {
     { "verbose",     no_argument,       NULL, 'v' },
@@ -86,6 +87,7 @@ static const struct option longopts[] = {
     { "threads",     required_argument, NULL, 't' },
     { "print-read-names", no_argument,  NULL, 'n' },
     { "full",        no_argument,       NULL, 'f' },
+    { "stdv",        no_argument,       NULL, OPT_STDV },
     { "progress",    required_argument, NULL, OPT_PROGRESS },
     { "help",        no_argument,       NULL, OPT_HELP },
     { "version",     no_argument,       NULL, OPT_VERSION },
@@ -398,6 +400,7 @@ void parse_eventalign_options(int argc, char** argv)
             case 't': arg >> opt::num_threads; break;
             case 'n': opt::print_read_names = true; break;
             case 'f': opt::full_output = true; break;
+            case OPT_STDV: model_stdv() = true; break;
             case 'v': opt::verbose++; break;
             case OPT_PROGRESS: opt::progress = true; break;
             case OPT_HELP:

--- a/src/main/nanopolish.cpp
+++ b/src/main/nanopolish.cpp
@@ -21,7 +21,7 @@ void initialize()
 
 void print_usage()
 {
-    printf("usage: nanopolish [command] [options]\n");
+    printf("usage: nanopolish [consensus|eventalign|getmodel] [options]\n");
 }
 
 int main(int argc, char** argv)

--- a/src/nanopolish_poremodel.cpp
+++ b/src/nanopolish_poremodel.cpp
@@ -12,14 +12,22 @@ void PoreModel::bake_gaussian_parameters()
 {
     for(int i = 0; i < PORE_MODEL_STATES; ++i) {
 
-        // these functions are provided by ONT
-        scaled_params[i].mean = state[i].level_mean * scale + shift;
-        scaled_params[i].stdv = state[i].level_stdv * var;
-        scaled_params[i].log_stdv = log(scaled_params[i].stdv); // pre-computed for efficiency
+        // as per ONT documents
+        scaled_state[i].level_mean = state[i].level_mean * scale + shift;
+        scaled_state[i].level_stdv = state[i].level_stdv * var;
 
-        // These are not used, for now
-        //scaled_state[i].sd_mean = state[i].sd_mean * scale_sd;
-        //scaled_state[i].sd_stdv = state[i].sd_stdv * sqrt(pow(scale_sd, 3.0) / var_sd);
+        scaled_state[i].sd_mean = state[i].sd_mean * scale_sd;
+        scaled_state[i].sd_lambda = state[i].sd_lambda * var_sd;
+        scaled_state[i].sd_stdv = sqrt(pow(scaled_state[i].sd_mean, 3) / scaled_state[i].sd_lambda);
+
+        // for efficiency
+        scaled_state[i].level_log_stdv = log(scaled_state[i].level_stdv);
+        scaled_state[i].sd_log_lambda = log(scaled_state[i].sd_lambda);
+
+        // for compatibility
+        scaled_params[i].mean = scaled_state[i].level_mean;
+        scaled_params[i].stdv = scaled_state[i].level_stdv;
+        scaled_params[i].log_stdv = scaled_state[i].level_log_stdv;
     }
     is_scaled = true;
 }

--- a/src/nanopolish_poremodel.h
+++ b/src/nanopolish_poremodel.h
@@ -19,9 +19,12 @@ struct PoreModelStateParams
 {
     double level_mean;
     double level_stdv;
-    
     double sd_mean;
     double sd_stdv;
+
+    double level_log_stdv;
+    double sd_lambda;
+    double sd_log_lambda;
 };
 
 //

--- a/src/nanopolish_poremodel.h
+++ b/src/nanopolish_poremodel.h
@@ -41,6 +41,12 @@ class PoreModel
             return scaled_params[kmer_rank];
         }
 
+        inline PoreModelStateParams get_scaled_state(const uint32_t kmer_rank) const
+        {
+            assert(is_scaled);
+            return scaled_state[kmer_rank];
+        }
+
         inline PoreModelStateParams get_parameters(const uint32_t kmer_rank) const
         {
             return state[kmer_rank];
@@ -64,6 +70,7 @@ class PoreModel
 
         //
         PoreModelStateParams state[PORE_MODEL_STATES];
+        PoreModelStateParams scaled_state[PORE_MODEL_STATES];
         GaussianParameters scaled_params[PORE_MODEL_STATES];
 };
 

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -92,6 +92,11 @@ void SquiggleRead::load_from_fast5(const std::string& fast5_path)
                                          static_cast<float>(curr.level_stdv), 
                                          static_cast<float>(curr.sd_mean),
                                          static_cast<float>(curr.sd_stdv) };
+            // set sd_lambda
+            pore_model[si].state[mi].level_log_stdv = log(pore_model[si].state[mi].level_stdv);
+            pore_model[si].state[mi].sd_lambda =
+                pow(pore_model[si].state[mi].sd_mean, 3.0) / pow(pore_model[si].state[mi].sd_stdv, 2.0);
+            pore_model[si].state[mi].sd_log_lambda = log(pore_model[si].state[mi].sd_lambda);
         }
 
         // Load the scaling parameters for the pore model

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -135,7 +135,8 @@ void SquiggleRead::load_from_fast5(const std::string& fast5_path)
             events[si][ei] = { static_cast<float>(f5_event.mean), 
                                static_cast<float>(f5_event.stdv), 
                                static_cast<float>(f5_event.start), 
-                               static_cast<float>(f5_event.length) }; 
+                               static_cast<float>(f5_event.length) };
+            events[si][ei].log_stdv = log(events[si][ei].stdv);
         }
     }
 

--- a/src/nanopolish_squiggle_read.h
+++ b/src/nanopolish_squiggle_read.h
@@ -21,6 +21,7 @@ struct SquiggleEvent
     float stdv;       // current level stdv
     float start_time; // start time of the event in seconds
     float duration;     // duration of the event in seconds
+    float log_stdv;   // precompute for efficiency
 };
 
 struct IndexPair
@@ -69,6 +70,18 @@ class SquiggleRead
         {
             assert(drift_correction_performed);
             return events[strand][event_idx].mean;
+        }
+
+        // Return the current stdv for the given event
+        inline float get_stdv(uint32_t event_idx, uint32_t strand) const
+        {
+            return events[strand][event_idx].stdv;
+        }
+
+        // Return log of the current stdv for the given event
+        inline float get_log_stdv(uint32_t event_idx, uint32_t strand) const
+        {
+            return events[strand][event_idx].log_stdv;
         }
         
         // Calculate the index of this k-mer on the other strand


### PR DESCRIPTION
This pull request adds stdv modelling as per the ONT documents and discussion. I separated the commits so that it's easier to review them one by one.

The main changes are:

- `SquiggleEvent` gets a precomputed `log_stdv` field.
- `PoreModelStateParams` gets `sd_lambda`, as well as precomputed `level_log_stdv` and `sd_log_lambda`.
- `PoreModel` keeps a `scaled_state` in addition to `state` and `scaled_parameters` arrays. The latter is now redundant, but some code still uses it, so I left it in to minimize changes.
- The emission code uses the new `scaled_state` to model both level and stdv.

Notably, the code that models stdv is still disabled by default. It can now be enabled by a command line switch.