### PR TITLE
train sd_mean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ share/
 
 3.2.5.tar.bz2
 eigen/
-local*/
+local*

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ hdf5-*/
 include/
 lib/
 share/
+
+3.2.5.tar.bz2
+eigen/
+local*/

--- a/src/alignment/nanopolish_eventalign.cpp
+++ b/src/alignment/nanopolish_eventalign.cpp
@@ -384,7 +384,7 @@ void emit_event_alignment_tsv(FILE* fp,
 
         // event information
         float event_mean = sr.get_drift_corrected_level(ea.event_idx, ea.strand_idx);
-        float event_stdv = sr.get_event_stdv(ea.event_idx, ea.strand_idx);
+        float event_stdv = sr.get_stdv(ea.event_idx, ea.strand_idx);
         float event_duration = sr.get_duration(ea.event_idx, ea.strand_idx);
         if(opt::scale_events) {
 

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -231,6 +231,7 @@ static const char *METHYLTRAIN_USAGE_MESSAGE =
 "  -s, --out-suffix=STR                 name output files like <strand>.out_suffix\n"
 "      --out-fofn=FILE                  write the names of the output models into FILE\n"
 "      --progress                       print out a progress message\n"
+"      --stdv                           enable stdv modelling\n"
 "\nReport bugs to " PACKAGE_BUGREPORT "\n\n";
 
 namespace opt
@@ -260,7 +261,8 @@ enum { OPT_HELP = 1,
        OPT_NO_UPDATE_MODELS, 
        OPT_TRAIN_KMERS, 
        OPT_OUTPUT_SCORES,
-       OPT_OUT_FOFN
+       OPT_OUT_FOFN,
+       OPT_STDV
      };
 
 static const struct option longopts[] = {
@@ -273,6 +275,7 @@ static const struct option longopts[] = {
     { "threads",            required_argument, NULL, 't' },
     { "models-fofn",        required_argument, NULL, 'm' },
     { "out-suffix",         required_argument, NULL, 's' },
+    { "stdv",               no_argument,       NULL, OPT_STDV },
     { "out-fofn",           required_argument, NULL, OPT_OUT_FOFN },
     { "train-kmers",        required_argument, NULL, OPT_TRAIN_KMERS },
     { "output-scores",      no_argument,       NULL, OPT_OUTPUT_SCORES },
@@ -622,6 +625,7 @@ void parse_methyltrain_options(int argc, char** argv)
             case 's': arg >> opt::out_suffix; break;
             case 'v': opt::verbose++; break;
             case 'c': opt::calibrate = 1; break;
+            case OPT_STDV: model_stdv() = true; break;
             case OPT_OUT_FOFN: arg >> opt::out_fofn; break;
             case OPT_OUTPUT_SCORES: opt::output_scores = true; break;
             case OPT_TRAIN_KMERS: arg >> training_target_str; break;

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -71,7 +71,7 @@ struct FullStateTrainingData
         // scale the observation to the expected pore model
         this->level_mean = sr.get_fully_scaled_level(ea.event_idx, ea.strand_idx);
         //this->event_stdv = sr.events[strand_idx][ea.event_idx].stdv / sr.pore_model[strand_idx].scale_sd;
-        this->level_stdv = sr.get_scaled_level_stdv(ea.event_idx, ea.strand_idx);
+        this->level_stdv = sr.get_scaled_stdv(ea.event_idx, ea.strand_idx);
         this->duration = sr.events[ea.strand_idx][ea.event_idx].duration;
         
         this->read_var = (float)sr.pore_model[ea.strand_idx].var;

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -135,38 +135,47 @@ struct MinimalStateTrainingData
     //
     MinimalStateTrainingData(const SquiggleRead& sr,
                              const EventAlignment& ea,
-                             uint32_t rank,
-                             const std::string& prev_kmer,
-                             const std::string& next_kmer)
+                             uint32_t,
+                             const std::string&,
+                             const std::string&)
     {
         // scale the observation to the expected pore model
         this->level_mean = sr.get_fully_scaled_level(ea.event_idx, ea.strand_idx);
+        this->level_stdv = sr.get_scaled_stdv(ea.event_idx, ea.strand_idx);
         this->read_var = (float)sr.pore_model[ea.strand_idx].var;
+        this->read_scale_sd = (float)sr.pore_model[ea.strand_idx].scale_sd;
+        this->read_var_sd = (float)sr.pore_model[ea.strand_idx].var_sd;
     }
 
     static void write_header(FILE* fp)
     {
-        fprintf(fp, "model\tmodel_kmer\tlevel_mean\tread_var\n");
+        fprintf(fp, "model\tmodel_kmer\tlevel_mean\tlevel_stdv\tread_var\tread_scale_sd\tread_var_sd\n");
     }
 
     void write_tsv(FILE* fp, const std::string& model_name, const std::string& kmer) const
     {
-        fprintf(fp, "%s\t%s\t%.2lf\t%.2lf\n",
-                    model_name.c_str(), 
-                    kmer.c_str(), 
-                    level_mean, 
-                    read_var);
+        fprintf(fp, "%s\t%s\t%.2lf\t%.2lf\t%.2lf\t%.2lf\t%.2lf\n",
+                    model_name.c_str(),
+                    kmer.c_str(),
+                    level_mean,
+                    level_stdv,
+                    read_var,
+                    read_scale_sd,
+                    read_var_sd);
     }
 
     //
     // Data
     //
     float level_mean;
+    float level_stdv;
     float read_var;
+    float read_scale_sd;
+    float read_var_sd;
 };
 
-//typedef MinimalStateTrainingData StateTrainingData;
-typedef FullStateTrainingData StateTrainingData;
+typedef MinimalStateTrainingData StateTrainingData;
+//typedef FullStateTrainingData StateTrainingData;
 
 struct StateSummary
 {

--- a/src/nanopolish_poremodel.cpp
+++ b/src/nanopolish_poremodel.cpp
@@ -20,20 +20,14 @@ void PoreModel::bake_gaussian_parameters()
 
     for(int i = 0; i < states.size(); ++i) {
 
-        // calculate the derived sd_lambda parameter
-        states[i].sd_lambda = pow(states[i].sd_mean, 3.0) / pow(states[i].sd_stdv, 2.0);
-
         // as per ONT documents
         scaled_states[i].level_mean = states[i].level_mean * scale + shift;
         scaled_states[i].level_stdv = states[i].level_stdv * var;
-
         scaled_states[i].sd_mean = states[i].sd_mean * scale_sd;
-        scaled_states[i].sd_lambda = states[i].sd_lambda * var_sd;
-        scaled_states[i].sd_stdv = sqrt(pow(scaled_states[i].sd_mean, 3) / scaled_states[i].sd_lambda);
+        scaled_states[i].set_sd_lambda(states[i].sd_lambda * var_sd);
 
         // for efficiency
-        scaled_states[i].level_log_stdv = log(scaled_states[i].level_stdv);
-        scaled_states[i].sd_log_lambda = log(scaled_states[i].sd_lambda);
+        scaled_states[i].update_logs();
 
         // for compatibility
         scaled_params[i].mean = scaled_states[i].level_mean;
@@ -145,10 +139,7 @@ PoreModel::PoreModel(fast5::File *f_p, const size_t strand, const Alphabet *alph
         const fast5::Model_Entry& curr = model[mi];
 
         std::string stringkmer(curr.kmer);
-        kmers[stringkmer] = { static_cast<float>(curr.level_mean),
-                              static_cast<float>(curr.level_stdv),
-                              static_cast<float>(curr.sd_mean),
-                              static_cast<float>(curr.sd_stdv) };
+        kmers[stringkmer] = curr;
         add_found_bases(bases, curr.kmer);
     }
 

--- a/src/nanopolish_poremodel.h
+++ b/src/nanopolish_poremodel.h
@@ -27,6 +27,31 @@ struct PoreModelStateParams
     double level_log_stdv;
     double sd_lambda;
     double sd_log_lambda;
+
+    PoreModelStateParams& operator = (const fast5::Model_Entry& e)
+    {
+        level_mean = e.level_mean;
+        level_stdv = e.level_stdv;
+        sd_mean = e.sd_mean;
+        set_sd_stdv(e.sd_stdv);
+        return *this;
+    }
+
+    void set_sd_stdv(double _sd_stdv)
+    {
+        sd_stdv = _sd_stdv;
+        sd_lambda = pow(sd_mean, 3.0) / pow(sd_stdv, 2.0);
+    }
+    void set_sd_lambda(double _sd_lambda)
+    {
+        sd_lambda = _sd_lambda;
+        sd_stdv = pow(pow(sd_mean, 3.0) / sd_lambda, .5);
+    }
+    void update_logs()
+    {
+        level_log_stdv = log(level_stdv);
+        sd_log_lambda = log(sd_lambda);
+    }
 };
 
 //

--- a/src/nanopolish_squiggle_read.h
+++ b/src/nanopolish_squiggle_read.h
@@ -85,12 +85,6 @@ class SquiggleRead
             return events[strand][event_idx].log_stdv;
         }
         
-        // Return the observed current level after correcting for drift
-        inline float get_event_stdv(uint32_t event_idx, uint32_t strand) const
-        {
-            return events[strand][event_idx].stdv;
-        }
-
         // Return the observed current level after correcting for drift, shift and scale
         inline float get_fully_scaled_level(uint32_t event_idx, uint32_t strand) const
         {
@@ -100,7 +94,7 @@ class SquiggleRead
         }
 
         // Return the observed current level stdv, after correcting for scale
-        inline float get_scaled_level_stdv(uint32_t event_idx, uint32_t strand) const
+        inline float get_scaled_stdv(uint32_t event_idx, uint32_t strand) const
         {
             return events[strand][event_idx].stdv / pore_model[strand].scale_sd;
         }


### PR DESCRIPTION
Initial version of `methyltrain` that trains the model `sd_mean`. This is enabled by the `--stdv` cl option. The code compiles and runs, but I didn't check if the results are actually reasonable.

Apart from training `sd_mean`, I made a few changes to other ares:

- I moved some of the computation related to `PoreModelStateParams` inside that struct. The problem here is that IGs have 2 parameters but 3 are being used at various points, the problematic overlap being between lambda and sigma. Each time one of them (or eta) is changed, the other has to change, too.

- Inside `train_one_round`, I moved up (and actually enabled) the code that skips kmers that are not being updated. The loop still writes to the training file and the summary file before continuing. I'm not sure if this is intended, but that's how it worked before, and I din't want to break things.