### PR TITLE
C++11 threads

### DIFF
--- a/src/common/pfor.hpp
+++ b/src/common/pfor.hpp
@@ -1,0 +1,209 @@
+/// @author    Matei David, Ontario Institute for Cancer Research
+/// @version   2.0
+/// @date      2013-2015
+/// @copyright MIT Public License
+///
+/// A parallel for loop.
+/// A parallel for loop that can re-sort its output, implemented
+/// in C++11.
+
+#ifndef __PFOR_HPP
+#define __PFOR_HPP
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include <queue>
+#include <functional>
+#include <thread>
+#include <mutex>
+#include <cassert>
+
+
+/// C++11 implementation of a parallel for loop that can re-sort its output.
+///
+/// Given a number of threads and a chunk size, the total work is split into
+/// chunks, each chunk is processed independently by a thread, and the outputs
+/// are reordered and processed in the same order they were read. More
+/// specifically:
+///   - The master thread starts `num_threads` worker threads, then waits for
+///     all workers. Each worker proceeds as follows:
+///   - Allocate a vector of `chunk_size` objects of type `Input` which are
+///     default-initialized.
+///   - Execute `do_before()`.
+///   - Repeatedly, until done:
+///     - Inside an input critical section: call `get_item()` repeatedly, getting
+///       up to `chunk_size` items. The `get_item()` function is expected to save
+///       an item in the Input given to it.
+///     - Allocate a new default-initialized Chunk_Output object (on the heap).
+///     - Repeatedly call `process_item()` in the order the items appear in the
+///       thread local buffer. The calls are given the same Chunk_Output object.
+///     - Inside an output critical section: the Chunk_Output object is added to
+///       a heap. As long as the chunk that must be output is in found in the
+///       heap, the corresponding Chunk_Output object is destroyed.
+///   - Execute `do_after()`.
+///
+/// Note: To re-sort the output, Chunk_Output should contain an
+/// ostringstream object that is used for output in `process_item()`, and that
+/// is flushed to std::cout upon destruction (which happens inside the output
+/// critical section).
+///
+/// @tparam Input Type of the input items.
+/// @tparam Chunk_Output Type of an object created during the processing of each
+/// chunk. Each such object is tagged with its chunk number, and placed in a
+/// priority queue. The objects are destroyed inside an output critical section
+/// in the order of their chunk numbers.
+/// @param do_before Function executed by each thread before any actual work.
+/// @param get_item Function executed inside an input critical section. If an item is
+/// available, the function is expected to save it in the `Input` location given
+/// as parameter and return true. If the items have been exhausted, the function
+/// is execpted to return false.
+/// @param process_item Function executed to process the given `Input` item. The
+/// `Output_Chunk` object will be the same for all items in that chunk.
+/// @param do_after Function executed by each thread after all work.
+/// @param num_threads Number of worker threads to spawn.
+/// @param chunk_size Number of items each thread should process in one chunk.
+//template < typename Input, typename Chunk_Output >
+template < typename PFor_Structs >
+void pfor(std::function< void(void) > do_before,
+          std::function< bool(typename PFor_Structs::Input&) > get_item,
+          std::function< void(typename PFor_Structs::Input&, typename PFor_Structs::Chunk_Output&) > process_item,
+          std::function< void(void) > do_after,
+          unsigned num_threads,
+          size_t chunk_size,
+          size_t chunk_progress = 0);
+
+/// @cond
+namespace detail
+{
+
+template < typename Chunk_Output >
+struct Chunk_Output_Wrapper
+    : public Chunk_Output
+{
+    Chunk_Output_Wrapper(unsigned tid_, unsigned cid_)
+        : Chunk_Output(), tid(tid_), cid(cid_) {}
+
+    unsigned tid;
+    unsigned cid;
+}; // struct Chunk_Output_Wrapper
+
+template < typename Chunk_Output >
+struct Chunk_Output_Wrapper_Ptr_Comparator
+{
+    bool operator () (const Chunk_Output_Wrapper< Chunk_Output >* lhs_p,
+                      const Chunk_Output_Wrapper< Chunk_Output >* rhs_p)
+    {
+        return lhs_p->cid > rhs_p->cid;
+    }
+};
+
+template < typename Chunk_Output >
+using Output_Heap = std::priority_queue< Chunk_Output_Wrapper< Chunk_Output >*,
+                                    std::vector< Chunk_Output_Wrapper< Chunk_Output >* >,
+                                    Chunk_Output_Wrapper_Ptr_Comparator< Chunk_Output > >;
+
+template < typename Chunk_Output >
+struct Common_Storage
+{
+    Common_Storage() : cid_in(0), cid_out(0) {}
+    size_t cid_in;
+    size_t cid_out;
+    std::mutex input_mutex;
+    std::mutex output_mutex;
+    Output_Heap< Chunk_Output > h;
+}; // struct Common_Storage
+
+template < typename Input, typename Chunk_Output >
+void do_work(std::function< void(void) > do_before,
+             std::function< bool(Input&) > get_item,
+             std::function< void(Input&, Chunk_Output&) > process_item,
+             std::function< void(void) > do_after,
+             size_t chunk_size,
+             size_t chunk_progress,
+             unsigned tid,
+             std::reference_wrapper< Common_Storage< Chunk_Output > > cs_wrap)
+{
+    Common_Storage< Chunk_Output >& cs = cs_wrap;
+    std::vector< Input > buff(chunk_size);
+    size_t load = 0;
+    size_t cid;
+    bool done = false;
+    if (do_before) do_before();
+    while (not done)
+    {
+        load = 0;
+        // input critical section
+        {
+            std::lock_guard< std::mutex > input_lock(cs.input_mutex);
+            cid = cs.cid_in++;
+            while (load < chunk_size and get_item(buff[load]))
+            {
+                ++load;
+            }
+            done = (load < chunk_size);
+            if (load > 0)
+            {
+                static_cast< void >(chunk_progress);
+            }
+        }
+        // parallel work
+        if (load == 0)
+        {
+            break;
+        }
+        Chunk_Output_Wrapper< Chunk_Output >* cow_p = new Chunk_Output_Wrapper< Chunk_Output >(tid, cid);
+        for (size_t i = 0; i < load; ++i)
+        {
+            process_item(buff[i], *cow_p);
+        }
+        // output critical section
+        {
+            std::lock_guard< std::mutex > output_lock(cs.output_mutex);
+            cs.h.push(cow_p);
+            while (cs.h.size() > 0)
+            {
+                cow_p = cs.h.top();
+                assert(cow_p->cid >= cs.cid_out);
+                if (cow_p->cid > cs.cid_out)
+                {
+                    break;
+                }
+                cs.h.pop();
+                delete cow_p;
+                cs.cid_out++;
+            }
+        }
+    }
+    if (do_after) do_after();
+} // do_work()
+
+} // namespace detail
+/// @endcond
+
+//template < typename Input, typename Chunk_Output >
+template < typename PFor_Structs >
+void pfor(std::function< void(void) > do_before,
+          std::function< bool(typename PFor_Structs::Input&) > get_item,
+          std::function< void(typename PFor_Structs::Input&, typename PFor_Structs::Chunk_Output&) > process_item,
+          std::function< void(void) > do_after,
+          unsigned num_threads,
+          size_t chunk_size,
+          size_t chunk_progress)
+{
+    std::vector< std::thread > thread_v;
+    detail::Common_Storage< typename PFor_Structs::Chunk_Output > cs;
+    for (unsigned i = 0; i < num_threads; ++i)
+    {
+        thread_v.emplace_back(detail::do_work< typename PFor_Structs::Input, typename PFor_Structs::Chunk_Output >,
+                              do_before, get_item, process_item, do_after,
+                              chunk_size, chunk_progress,
+                              i, std::ref(cs));
+    }
+    for (auto& t : thread_v)
+    {
+        t.join();
+    }
+} // pfor()
+
+#endif

--- a/src/common/pfor.hpp
+++ b/src/common/pfor.hpp
@@ -9,14 +9,15 @@
 #ifndef __PFOR_HPP
 #define __PFOR_HPP
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <functional>
 #include <mutex>
 #include <queue>
-#include <vector>
 #include <thread>
 #include <type_traits>
+#include <vector>
 
 namespace pfor
 {
@@ -330,14 +331,13 @@ void pfor(unsigned num_threads,
 #ifdef PFOR_SAMPLE
 /*
 
-Compile:
+Compile with:
 
-g++ -std=c++11 -D PFOR_SAMPLE -x c++ pfor.hpp -o pfor
+g++ -std=c++11 -pthread -D PFOR_SAMPLE -x c++ pfor.hpp -o pfor
 
 */
 
 #include <iostream>
-#include <iomanip>
 #include <sstream>
 
 using namespace std;
@@ -391,7 +391,7 @@ int main()
         // process_item
         [&] (unsigned& i, std::ostringstream& os) {
             thread::id this_id = this_thread::get_id();
-            os << setw(3) << right << this_id << ": " << i << "*" << i << "=" << i*i << endl;
+            os << this_id << ": " << i << "*" << i << "=" << i*i << endl;
         },
         // output_chunk
         [&] (std::ostringstream& os) {

--- a/src/common/pfor.hpp
+++ b/src/common/pfor.hpp
@@ -63,11 +63,10 @@
 /// @param do_after Function executed by each thread after all work.
 /// @param num_threads Number of worker threads to spawn.
 /// @param chunk_size Number of items each thread should process in one chunk.
-//template < typename Input, typename Chunk_Output >
-template < typename PFor_Structs >
+template < typename Input, typename Chunk_Output >
 void pfor(std::function< void(void) > do_before,
-          std::function< bool(typename PFor_Structs::Input&) > get_item,
-          std::function< void(typename PFor_Structs::Input&, typename PFor_Structs::Chunk_Output&) > process_item,
+          std::function< bool(Input&) > get_item,
+          std::function< void(Input&, Chunk_Output&) > process_item,
           std::function< void(void) > do_after,
           unsigned num_threads,
           size_t chunk_size,
@@ -181,21 +180,20 @@ void do_work(std::function< void(void) > do_before,
 } // namespace detail
 /// @endcond
 
-//template < typename Input, typename Chunk_Output >
-template < typename PFor_Structs >
+template < typename Input, typename Chunk_Output >
 void pfor(std::function< void(void) > do_before,
-          std::function< bool(typename PFor_Structs::Input&) > get_item,
-          std::function< void(typename PFor_Structs::Input&, typename PFor_Structs::Chunk_Output&) > process_item,
+          std::function< bool(Input&) > get_item,
+          std::function< void(Input&, Chunk_Output&) > process_item,
           std::function< void(void) > do_after,
           unsigned num_threads,
           size_t chunk_size,
           size_t chunk_progress)
 {
     std::vector< std::thread > thread_v;
-    detail::Common_Storage< typename PFor_Structs::Chunk_Output > cs;
+    detail::Common_Storage< Chunk_Output > cs;
     for (unsigned i = 0; i < num_threads; ++i)
     {
-        thread_v.emplace_back(detail::do_work< typename PFor_Structs::Input, typename PFor_Structs::Chunk_Output >,
+        thread_v.emplace_back(detail::do_work< Input, Chunk_Output >,
                               do_before, get_item, process_item, do_after,
                               chunk_size, chunk_progress,
                               i, std::ref(cs));

--- a/src/common/pfor.hpp
+++ b/src/common/pfor.hpp
@@ -4,27 +4,28 @@
 /// @copyright MIT Public License
 ///
 /// A parallel for loop.
-/// A parallel for loop that can re-sort its output, implemented
-/// in C++11.
+/// A parallel for loop that can re-sort its output, implemented in C++11.
 
 #ifndef __PFOR_HPP
 #define __PFOR_HPP
 
 #include <cassert>
-#include <iostream>
-#include <sstream>
-#include <vector>
-#include <queue>
-#include <functional>
-#include <thread>
-#include <mutex>
 #include <chrono>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <vector>
+#include <thread>
+#include <type_traits>
 
-/// C++11 implementation of a parallel for loop that can re-sort its output.
+namespace pfor
+{
+
+/// C++11 implementation of a parallel for loop.
 ///
 /// Given a number of threads and a chunk size, the total work is split into
-/// chunks, each chunk is processed independently by a thread, and the outputs
-/// are reordered and processed in the same order they were read. More
+/// chunks, each chunk is processed independently by a thread. Optionally, the
+/// outputs can be reordered in the same order they were read. More
 /// specifically:
 ///   - The master thread starts `num_threads` worker threads, then waits for
 ///     all workers. Each worker proceeds as follows:
@@ -32,42 +33,62 @@
 ///     default-initialized.
 ///   - Execute `do_before()`.
 ///   - Repeatedly, until done:
-///     - Inside an input critical section: call `get_item()` repeatedly, getting
-///       up to `chunk_size` items. The `get_item()` function is expected to save
-///       an item in the Input given to it.
-///     - Allocate a new default-initialized Chunk_Output object (on the heap).
+///     - Inside an input critical section: call `get_item()` repeatedly,
+///       getting up to `chunk_size` items. The `get_item()` function should
+///       save an item in the `Input` location given as parameter.
+///     - If `Chunk_Output` is given:
+///       - Allocate a new default-initialized Chunk_Output object on the heap.
 ///     - Repeatedly call `process_item()` in the order the items appear in the
-///       thread local buffer. The calls are given the same Chunk_Output object.
-///     - Inside an output critical section: the Chunk_Output object is added to
-///       a heap. As long as the chunk that must be output is in found in the
-///       heap, the corresponding Chunk_Output object is destroyed.
+///       thread local buffer. If `Chunk_Output` is given, the calls are passed
+///       the same `Chunk_Output` object.
+///     - If `Chunk_Output` is given: Inside an output critical section, the
+///       `Chunk_Output` object is added to a heap. As long as the chunk that
+///       must be output next is in found in the heap, `output_chunk` is called
+///       on that object, after which it is destroyed.
 ///   - Execute `do_after()`.
 ///
-/// Note: To re-sort the output, Chunk_Output should contain an
-/// ostringstream object that is used for output in `process_item()`, and that
-/// is flushed to std::cout upon destruction (which happens inside the output
-/// critical section).
+/// To ENABLE output sorting:
+/// - `Chunk_Output` should contain one (or more) ostringstream object(s);
+/// - `process_item()` should take 2 arguments, the second being a
+/// `Chunk_Output` object; the ostringstream inside that `Chunk_Output` should
+/// be used for output inside `process_item()`;
+/// - `output_chunk()` should flush the ostringstream to output.
+///
+/// To DISABLE output sorting:
+/// - `Chunk_Output` should not be specified;
+/// - `process_item()` should take 1 argument only;
+/// - `output_chunk()` should not be specified.
 ///
 /// @tparam Input Type of the input items.
-/// @tparam Chunk_Output Type of an object created during the processing of each
-/// chunk. Each such object is tagged with its chunk number, and placed in a
-/// priority queue. The objects are destroyed inside an output critical section
-/// in the order of their chunk numbers.
-/// @param do_before Function executed by each thread before any actual work.
-/// @param get_item Function executed inside an input critical section. If an item is
-/// available, the function is expected to save it in the `Input` location given
-/// as parameter and return true. If the items have been exhausted, the function
-/// is execpted to return false.
-/// @param process_item Function executed to process the given `Input` item. The
-/// `Output_Chunk` object will be the same for all items in that chunk.
-/// @param do_after Function executed by each thread after all work.
+/// @tparam Chunk_Output (optional) Type of an object created during the
+/// processing of each chunk. Each such object is tagged with its chunk number,
+/// and placed in a priority queue. The objects are destroyed inside an output
+/// critical section in the order of their chunk numbers.
 /// @param num_threads Number of worker threads to spawn.
 /// @param chunk_size Number of items each thread should process in one chunk.
-template < typename Input, typename Chunk_Output >
+/// @param get_item Function executed inside an input critical section. If an
+/// item is available, the function should save it in the `Input` location given
+/// as parameter, and return true. If the items have been exhausted, the
+/// function should return false.
+/// @param process_item Function executed to process the given `Input` item. If
+/// output sorting is enabled, the function takes as second argument a
+/// `Chunk_Output` object that will be the same for all items in that chunk.
+/// @param output_chunk (optional) Function called on a `Chunk_Output`
+/// object inside an output critical section before it is destroyed.
+/// @param do_before Function executed by each thread before any actual work.
+/// @param do_after Function executed by each thread after all work.
+/// @progress_report Function that will be called to report progress with 2
+/// arguments: the number of items processed, and the number of seconds
+/// elapsed so far.
+/// @progress_count Number of items that should be processed between calls to
+/// `progress_report`. (This will be rounded down to be divisible by
+/// `chunk_size`).
+
+template < typename Input >
 void pfor(unsigned num_threads,
           size_t chunk_size,
           std::function< bool(Input&) > get_item,
-          std::function< void(Input&, Chunk_Output&) > process_item,
+          std::function< void(Input&) > process_item,
           std::function< void(size_t, size_t) > progress_report = nullptr,
           size_t progress_count = 0);
 
@@ -76,6 +97,16 @@ void pfor(unsigned num_threads,
           size_t chunk_size,
           std::function< bool(Input&) > get_item,
           std::function< void(Input&, Chunk_Output&) > process_item,
+          std::function< void(Chunk_Output&) > output_chunk,
+          std::function< void(size_t, size_t) > progress_report = nullptr,
+          size_t progress_count = 0);
+
+template < typename Input, typename Chunk_Output >
+void pfor(unsigned num_threads,
+          size_t chunk_size,
+          std::function< bool(Input&) > get_item,
+          std::function< void(Input&, Chunk_Output&) > process_item,
+          std::function< void(Chunk_Output&) > output_chunk,
           std::function< void(void) > do_before,
           std::function< void(void) > do_after,
           std::function< void(size_t, size_t) > progress_report = nullptr,
@@ -84,6 +115,8 @@ void pfor(unsigned num_threads,
 /// @cond
 namespace detail
 {
+
+struct empty {};
 
 template < typename Chunk_Output >
 struct Chunk_Output_Wrapper
@@ -116,6 +149,7 @@ struct Common_Storage
 {
     std::function< bool(Input&) > get_item;
     std::function< void(Input&, Chunk_Output&) > process_item;
+    std::function< void(Chunk_Output&) > output_chunk;
     std::function< void(void) > do_before;
     std::function< void(void) > do_after;
     std::function< void(size_t, size_t) > progress_report;
@@ -130,10 +164,11 @@ struct Common_Storage
     Output_Heap< Chunk_Output > h;
 }; // struct Common_Storage
 
-template < typename Input, typename Chunk_Output >
+template < typename Input, typename Chunk_Output, bool sort_output >
 void do_work(unsigned tid, std::reference_wrapper< Common_Storage< Input, Chunk_Output > > cs_wrap)
 {
     Common_Storage< Input, Chunk_Output >& cs = cs_wrap;
+    Chunk_Output_Wrapper< Chunk_Output > _empty_wrapper(tid, 0);
     std::vector< Input > buff(cs.chunk_size);
     size_t load = 0;
     size_t cid;
@@ -157,7 +192,11 @@ void do_work(unsigned tid, std::reference_wrapper< Common_Storage< Input, Chunk_
         {
             break;
         }
-        Chunk_Output_Wrapper< Chunk_Output >* cow_p = new Chunk_Output_Wrapper< Chunk_Output >(tid, cid);
+        Chunk_Output_Wrapper< Chunk_Output >* cow_p = &_empty_wrapper;
+        if (sort_output)
+        {
+            cow_p = new Chunk_Output_Wrapper< Chunk_Output >(tid, cid);
+        }
         for (size_t i = 0; i < load; ++i)
         {
             cs.process_item(buff[i], *cow_p);
@@ -172,18 +211,25 @@ void do_work(unsigned tid, std::reference_wrapper< Common_Storage< Input, Chunk_
                 auto elapsed = std::chrono::duration_cast< std::chrono::seconds >(crt_time - cs.start_time);
                 cs.progress_report(cs.item_count, elapsed.count());
             }
-            cs.h.push(cow_p);
-            while (cs.h.size() > 0)
+            if (sort_output)
             {
-                cow_p = cs.h.top();
-                assert(cow_p->cid >= cs.cid_out);
-                if (cow_p->cid > cs.cid_out)
+                cs.h.push(cow_p);
+                while (cs.h.size() > 0)
                 {
-                    break;
+                    cow_p = cs.h.top();
+                    assert(cow_p->cid >= cs.cid_out);
+                    if (cow_p->cid > cs.cid_out)
+                    {
+                        break;
+                    }
+                    cs.h.pop();
+                    if (cs.output_chunk)
+                    {
+                        cs.output_chunk(*cow_p);
+                    }
+                    delete cow_p;
+                    cs.cid_out++;
                 }
-                cs.h.pop();
-                delete cow_p;
-                cs.cid_out++;
             }
         }
     }
@@ -198,6 +244,7 @@ void pfor(unsigned num_threads,
           size_t chunk_size,
           std::function< bool(Input&) > get_item,
           std::function< void(Input&, Chunk_Output&) > process_item,
+          std::function< void(Chunk_Output&) > output_chunk,
           std::function< void(void) > do_before,
           std::function< void(void) > do_after,
           std::function< void(size_t, size_t) > progress_report,
@@ -207,6 +254,7 @@ void pfor(unsigned num_threads,
     detail::Common_Storage< Input, Chunk_Output > cs;
     cs.get_item = get_item;
     cs.process_item = process_item;
+    cs.output_chunk = output_chunk;
     cs.do_before = do_before;
     cs.do_after = do_after;
     cs.progress_report = progress_report;
@@ -217,15 +265,16 @@ void pfor(unsigned num_threads,
     cs.cid_in = 0;
     cs.cid_out = 0;
     cs.start_time = std::chrono::system_clock::now();
+    static const bool sort_output = not std::is_same< Chunk_Output, detail::empty >::value;
     for (unsigned i = 0; i < num_threads; ++i)
     {
-        thread_v.emplace_back(detail::do_work< Input, Chunk_Output >, i, std::ref(cs));
+        thread_v.emplace_back(detail::do_work< Input, Chunk_Output, sort_output >, i, std::ref(cs));
     }
     for (auto& t : thread_v)
     {
         t.join();
     }
-    if (cs.progress_report)
+    if (cs.progress_report and cs.item_count % cs.progress_count != 0)
     {
         auto crt_time = std::chrono::system_clock::now();
         auto elapsed = std::chrono::duration_cast< std::chrono::seconds >(crt_time - cs.start_time);
@@ -233,16 +282,121 @@ void pfor(unsigned num_threads,
     }
 } // pfor()
 
+template < typename Input >
+void pfor(unsigned num_threads,
+          size_t chunk_size,
+          std::function< bool(Input&) > get_item,
+          std::function< void(Input&) > process_item,
+          std::function< void(size_t, size_t) > progress_report,
+          size_t progress_count)
+{
+    pfor< Input, detail::empty >(
+        num_threads,
+        chunk_size,
+        get_item,
+        [&] (Input& in, detail::empty&) { process_item(in); },
+        nullptr,
+        nullptr,
+        nullptr,
+        progress_report,
+        progress_count);
+} // pfor()
+
 template < typename Input, typename Chunk_Output >
 void pfor(unsigned num_threads,
           size_t chunk_size,
           std::function< bool(Input&) > get_item,
           std::function< void(Input&, Chunk_Output&) > process_item,
+          std::function< void(Chunk_Output&) > output_chunk,
           std::function< void(size_t, size_t) > progress_report,
           size_t progress_count)
 {
     pfor< Input, Chunk_Output >(
-        num_threads, chunk_size, get_item, process_item, nullptr, nullptr, progress_report, progress_count);
+        num_threads,
+        chunk_size,
+        get_item,
+        process_item,
+        output_chunk,
+        nullptr,
+        nullptr,
+        progress_report,
+        progress_count);
 } // pfor()
+
+} // namespace pfor
+
+#endif
+
+#ifdef PFOR_SAMPLE
+/*
+
+Compile:
+
+g++ -std=c++11 -D PFOR_SAMPLE -x c++ pfor.hpp -o pfor
+
+*/
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+
+int main()
+{
+    //
+    // pfor loop WITHOUT output sorting
+    //
+    vector< unsigned > v(1000);
+    unsigned crt_idx = 0;
+    pfor::pfor< unsigned >(
+        // num_threads
+        4,
+        // chunk_size
+        10,
+        // get_item
+        [&] (unsigned& i) {
+            if (crt_idx >= v.size()) return false;
+            i = crt_idx++;
+            return true;
+        },
+        // process_item
+        [&] (unsigned& i) {
+            v[i] = i*i;
+        },
+        //
+        // The following 2 parameters are optional
+        //
+        // progress_report
+        [&] (size_t items, size_t seconds) {
+            cout << "processed " << items << " items in " << seconds << " seconds" << endl;
+        },
+        // progress_count
+        110);
+    //
+    // pfor loop WITH output sorting
+    //
+    crt_idx = 0;
+    pfor::pfor< unsigned, std::ostringstream >(
+        // num_threads
+        4,
+        // chunk_size
+        1,
+        // get_item
+        [&] (unsigned& i) {
+            if (crt_idx >= 10) return false;
+            i = crt_idx++;
+            return true;
+        },
+        // process_item
+        [&] (unsigned& i, std::ostringstream& os) {
+            thread::id this_id = this_thread::get_id();
+            os << setw(3) << right << this_id << ": " << i << "*" << i << "=" << i*i << endl;
+        },
+        // output_chunk
+        [&] (std::ostringstream& os) {
+            cout << os.str();
+        });
+}
 
 #endif

--- a/src/common/progress.h
+++ b/src/common/progress.h
@@ -9,7 +9,9 @@
 #ifndef PROGRESS_H
 #define PROGRESS_H
 
-#include <time.h>
+#include <iostream>
+#include <string>
+#include <chrono>
 
 class Progress
 {
@@ -17,13 +19,7 @@ class Progress
         
         Progress(const std::string message) : m_message(message), m_os(std::cerr)
         {
-#if HAVE_CLOCK_GETTIME            
-            timespec start;
-            clock_gettime(CLOCK_REALTIME, &start);
-            m_start_time = start.tv_sec;
-#else
-            m_start_time = 0;
-#endif
+            m_start_time = std::chrono::system_clock::now();
         }
 
         // derived from: http://stackoverflow.com/a/14539953/378881
@@ -60,23 +56,19 @@ class Progress
             std::cerr << std::endl;
         }
 
-        double get_elapsed_seconds() const
+        size_t get_elapsed_seconds() const
         {
             // get current time
-#if HAVE_CLOCK_GETTIME            
-            timespec now;
-            clock_gettime(CLOCK_REALTIME, &now);
-            return now.tv_sec - m_start_time;
-#else
-            return 0;
-#endif
+            auto now_time = std::chrono::system_clock::now();
+            auto elapsed = std::chrono::duration_cast< std::chrono::seconds >(now_time - m_start_time);
+            return elapsed.count();
         }
 
     private:
 
         std::ostream& m_os;
         std::string m_message;
-        size_t m_start_time;
+        std::chrono::system_clock::time_point m_start_time;
 };
 
 #endif

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -601,7 +601,7 @@ ModelMap train_one_round(const ModelMap& models, const Fast5Map& name_map, size_
     size_t crt_read_idx = 0;
     pfor< Mapping_PFor_Structs::Input, Mapping_PFor_Structs::Chunk_Output >(
         opt::num_threads,
-        1,
+        10,
         // get_item
         [&] (Mapping_PFor_Structs::Input& in) {
             auto res = sam_itr_next(bam_fh, itr, in.bam_rec_p) >= 0;
@@ -620,7 +620,9 @@ ModelMap train_one_round(const ModelMap& models, const Fast5Map& name_map, size_
         [&] (size_t items, size_t seconds) {
             std::clog << "Processed " << std::setw(6) << std::right << items << " reads in "
                       << std::setw(6) << std::right << seconds << " seconds\r";
-        });
+        },
+        // progress_count
+        100);
     std::clog << std::endl;
 
     std::stringstream training_fn;
@@ -669,7 +671,7 @@ ModelMap train_one_round(const ModelMap& models, const Fast5Map& name_map, size_
         Training_PFor_Structs::Chunk_Output::summary_sink_osp() = &summary_ofs;
         pfor< Training_PFor_Structs::Input, Training_PFor_Structs::Chunk_Output >(
             opt::num_threads,
-            10,
+            50,
             // get_item
             [&] (Training_PFor_Structs::Input& in) {
                 if (crt_input.ki >= summaries.size())
@@ -769,10 +771,13 @@ ModelMap train_one_round(const ModelMap& models, const Fast5Map& name_map, size_
                 new_pm.states[ki].update_logs();
             } // if model_stdv()
             }, // process_item
+            // progress_report
             [&] (size_t items, size_t seconds) {
                 std::clog << "Processed " << std::setw(6) << std::right << items << " kmers in "
                           << std::setw(6) << std::right << seconds << " seconds\r";
-            }); // pfor
+            },
+            // progress_count
+            1000); // pfor
             std::clog << std::endl;
     } // model_training_iter
 

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -601,7 +601,7 @@ ModelMap train_one_round(const ModelMap& models, const Fast5Map& name_map, size_
         }
 
         if(opt::progress) {
-            fprintf(stderr, "Realigned %zu reads in %.1lfs\r", num_reads_realigned, progress.get_elapsed_seconds());
+            fprintf(stderr, "Realigned %zu reads in %lus\r", num_reads_realigned, progress.get_elapsed_seconds());
         }
     } while(result >= 0);
     

--- a/src/training_core.hpp
+++ b/src/training_core.hpp
@@ -52,7 +52,7 @@ struct MinimalStateTrainingData
 
     void write_tsv(std::ostream& os, const std::string& model_name, const std::string& kmer) const
     {
-        write_tsv(os, model_name, kmer);
+        write_tsv_nonl(os, model_name, kmer);
         os << std::endl;
     }
     void write_tsv_nonl(std::ostream& os, const std::string& model_name, const std::string& kmer) const

--- a/src/training_core.hpp
+++ b/src/training_core.hpp
@@ -117,7 +117,7 @@ struct FullStateTrainingData
 
     void write_tsv(std::ostream& os, const std::string& model_name, const std::string& kmer) const
     {
-        write_tsv(os, model_name, kmer);
+        write_tsv_nonl(os, model_name, kmer);
         os << std::endl;
     }
     void write_tsv_nonl(std::ostream& os, const std::string& model_name, const std::string& kmer) const


### PR DESCRIPTION
- replaced omp by c++11 threading and custom pfor wrapper (in `nanopolish_methyltrain.cpp` only)
- implemented parallel kmer training
- replaced `clock_gettime` by c++11 chrono, but then disabled `progress.h` in favour of custom progress
- added pfor sample usage inside `pfor.hpp`
