### PR TITLE
Use angle-bracket includes to allow flexibile placement of dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ HTS_LIB=./htslib/libhts.a
 HTS_INCLUDE=-I./htslib
 
 # Include the header-only fast5 library
-FAST5_INCLUDE=-I./fast5
+FAST5_INCLUDE=-I./fast5/src
 
 # Include the src subdirectories
 NP_INCLUDE=$(addprefix -I./, $(SUBDIRS))

--- a/src/nanopolish_poremodel.cpp
+++ b/src/nanopolish_poremodel.cpp
@@ -11,7 +11,7 @@
 #include <sstream>
 #include <cstring>
 #include <bits/stl_algo.h>
-#include "../fast5/src/fast5.hpp"
+#include <fast5.hpp>
 
 void PoreModel::bake_gaussian_parameters()
 {

--- a/src/nanopolish_poremodel.h
+++ b/src/nanopolish_poremodel.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <map>
 #include "nanopolish_model_names.h"
-#include "../fast5/src/fast5.hpp"
+#include <fast5.hpp>
 
 //
 struct PoreModelStateParams

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -11,7 +11,7 @@
 #include "nanopolish_squiggle_read.h"
 #include "nanopolish_pore_model_set.h"
 #include "nanopolish_methyltrain.h"
-#include "src/fast5.hpp"
+#include <fast5.hpp>
 
 //
 SquiggleRead::SquiggleRead(const std::string& name, const std::string& path, const uint32_t flags) :


### PR DESCRIPTION
Using -I in the C preprocessor flags adds the specified directories
to the search path. Taking advantage of this, we can use angle-brackets
for the include statements to avoid hardcoding the location of dependencies and
to ease use of externally installed versions.
