### PR TITLE
clean up warnings

### DIFF
--- a/src/alignment/nanopolish_alignment_db.cpp
+++ b/src/alignment/nanopolish_alignment_db.cpp
@@ -210,7 +210,7 @@ std::vector<Variant> AlignmentDB::get_variants_in_region(const std::string& cont
         size_t count = iter->second.second;
         size_t d = depth[v.ref_position - start_position];
         double f = (double)count / d;
-        if(f >= min_frequency && d >= min_depth) {
+        if(f >= min_frequency && (int)d >= min_depth) {
             v.add_info("BaseCalledReadsWithVariant", count);
             v.add_info("BaseCalledFrequency", f);
             variants.push_back(v);

--- a/src/alignment/nanopolish_alignment_db.cpp
+++ b/src/alignment/nanopolish_alignment_db.cpp
@@ -26,10 +26,10 @@ AlignmentDB::AlignmentDB(const std::string& reads_file,
                          const std::string& reference_file,
                          const std::string& sequence_bam,
                          const std::string& event_bam) :
-                            m_fast5_name_map(reads_file),
                             m_reference_file(reference_file),
                             m_sequence_bam(sequence_bam),
-                            m_event_bam(event_bam)
+                            m_event_bam(event_bam),
+                            m_fast5_name_map(reads_file)
 {
     m_p_model_map = NULL;
     _clear_region();

--- a/src/alignment/nanopolish_alignment_db.cpp
+++ b/src/alignment/nanopolish_alignment_db.cpp
@@ -161,7 +161,7 @@ std::vector<Variant> AlignmentDB::get_variants_in_region(const std::string& cont
     std::map<std::string, std::pair<Variant, int>> map;
     std::vector<int> depth(stop_position - start_position + 1, 0);
 
-    size_t num_aligned_reads = 0;
+    //size_t num_aligned_reads = 0;
 
     for(size_t i = 0; i < m_sequence_records.size(); ++i) {
         const SequenceAlignmentRecord& record = m_sequence_records[i];

--- a/src/alignment/nanopolish_anchor.cpp
+++ b/src/alignment/nanopolish_anchor.cpp
@@ -109,7 +109,7 @@ HMMRealignmentInput build_input_for_region(const std::string& bam_filename,
                 read_kidx = sr.flip_k_strand(read_kidx);
 
             // If the aligned base is beyong the start of the last k-mer of the read, skip
-            if(read_kidx >= sr.read_sequence.size() - k + 1) {
+            if(read_kidx >= (int)(sr.read_sequence.size() - k + 1)) {
                 continue;
             }
 
@@ -117,8 +117,8 @@ HMMRealignmentInput build_input_for_region(const std::string& bam_filename,
             int complement_idx = sr.get_closest_event_to(read_kidx, C_IDX);
 
             assert(template_idx != -1 && complement_idx != -1);
-            assert(template_idx < sr.events[T_IDX].size());
-            assert(complement_idx < sr.events[C_IDX].size());
+            assert(template_idx < (int)sr.events[T_IDX].size());
+            assert(complement_idx < (int)sr.events[C_IDX].size());
 
             event_anchors.strand_anchors[T_IDX][ai] = { template_idx, template_rc };
             event_anchors.strand_anchors[C_IDX][ai] = { complement_idx, complement_rc };
@@ -196,7 +196,7 @@ HMMRealignmentInput build_input_for_region(const std::string& bam_filename,
             
             // base, these sequences need to overlap by k - 1 bases
             int base_length = stride + k;
-            if(ai * stride + base_length > fetched_len)
+            if((int)ai * stride + base_length > fetched_len)
                 base_length = fetched_len - ai * stride;
 
             column.base_sequence = std::string(ref_segment + ai * stride, base_length);

--- a/src/alignment/nanopolish_anchor.cpp
+++ b/src/alignment/nanopolish_anchor.cpp
@@ -59,7 +59,7 @@ HMMRealignmentInput build_input_for_region(const std::string& bam_filename,
     std::vector<std::vector<std::string>> read_substrings;
 
     // kmer size of pore model
-    uint32_t k;
+    uint32_t k = 0;
 
     // Load the SquiggleReads aligned to this region and the bases
     // that are mapped to our reference anchoring positions
@@ -227,8 +227,8 @@ std::vector<AlignedPair> get_aligned_pairs(const bam1_t* record, int read_stride
     std::vector<AlignedPair> out;
 
     // This code is derived from bam_fillmd1_core
-    uint8_t *ref = NULL;
-    uint8_t *seq = bam_get_seq(record);
+    //uint8_t *ref = NULL;
+    //uint8_t *seq = bam_get_seq(record);
     uint32_t *cigar = bam_get_cigar(record);
     const bam1_core_t *c = &record->core;
 

--- a/src/alignment/nanopolish_anchor.cpp
+++ b/src/alignment/nanopolish_anchor.cpp
@@ -238,7 +238,7 @@ std::vector<AlignedPair> get_aligned_pairs(const bam1_t* record, int read_stride
 
     // query pos is an index in the query string that is recorded in the bam
     // we record this as a sanity check
-    int query_pos = 0;
+    //int query_pos = 0;
     
     int ref_pos = c->pos;
 

--- a/src/alignment/nanopolish_eventalign.cpp
+++ b/src/alignment/nanopolish_eventalign.cpp
@@ -431,7 +431,7 @@ EventalignSummary summarize_alignment(const SquiggleRead& sr,
     size_t prev_ref_pos = std::string::npos;
     
     // the number of unique reference positions seen in the alignment
-    size_t num_unique_ref_pos = 0;
+    //size_t num_unique_ref_pos = 0;
 
     for(size_t i = 0; i < alignments.size(); ++i) {
 
@@ -604,7 +604,6 @@ std::vector<EventAlignment> align_read_to_ref(const EventAlignmentParameters& pa
     int last_event = params.sr->get_closest_event_to(read_kidx_end, params.strand_idx);
     bool forward = first_event < last_event;
 
-    int last_event_output = -1;
     int curr_start_event = first_event;
     int curr_start_ref = aligned_pairs.front().ref_pos;
     int curr_pair_idx = 0;

--- a/src/alignment/nanopolish_eventalign.cpp
+++ b/src/alignment/nanopolish_eventalign.cpp
@@ -172,7 +172,7 @@ void trim_aligned_pairs_to_ref_region(std::vector<AlignedPair>& aligned_pairs, i
 // that is not greater than ref_pos_max. It starts the search at pair_idx
 int get_end_pair(const std::vector<AlignedPair>& aligned_pairs, int ref_pos_max, int pair_idx)
 {
-    while(pair_idx < aligned_pairs.size()) {
+    while(pair_idx < (int)aligned_pairs.size()) {
         if(aligned_pairs[pair_idx].ref_pos > ref_pos_max)
             return pair_idx - 1;
         pair_idx += 1;
@@ -660,7 +660,7 @@ std::vector<EventAlignment> align_read_to_ref(const EventAlignmentParameters& pa
         size_t event_align_idx = 0;
 
         // If we aligned to the last event, output everything and stop
-        bool last_section = end_pair_idx == aligned_pairs.size() - 1;
+        bool last_section = end_pair_idx == (int)aligned_pairs.size() - 1;
 
         int last_event_output = 0;
         int last_ref_kmer_output = 0;
@@ -669,7 +669,7 @@ std::vector<EventAlignment> align_read_to_ref(const EventAlignmentParameters& pa
               (num_output < output_stride || last_section); event_align_idx++) {
 
             HMMAlignmentState& as = event_alignment[event_align_idx];
-            if(as.state != 'K' && as.event_idx != curr_start_event) {
+            if(as.state != 'K' && (int)as.event_idx != curr_start_event) {
 
                 EventAlignment ea;
                 

--- a/src/common/nanopolish_alphabet.h
+++ b/src/common/nanopolish_alphabet.h
@@ -246,9 +246,9 @@ class Alphabet
 
 #define BASIC_ACCESSOR_BOILERPLATE \
     virtual std::string get_name() const { return _name; } \
-    virtual uint8_t rank(char b) const { return _rank[b]; } \
+    virtual uint8_t rank(char b) const { return _rank[(int)b]; }        \
     virtual char base(uint8_t r) const { return _base[r]; } \
-    virtual char complement(char b) const { return _complement[_rank[b]]; } \
+    virtual char complement(char b) const { return _complement[_rank[(int)b]]; } \
     virtual uint32_t size() const { return _size; } \
 
 struct DNAAlphabet : public Alphabet

--- a/src/common/nanopolish_alphabet.h
+++ b/src/common/nanopolish_alphabet.h
@@ -18,8 +18,8 @@
 
 struct RecognitionMatch
 {
-    int offset; // the matched position in the recognition site
-    int length; // the length of the match, 0 indicates no match
+    unsigned offset; // the matched position in the recognition site
+    unsigned length; // the length of the match, 0 indicates no match
     bool covers_methylated_site; // does the match cover an M base?
 };
 

--- a/src/common/nanopolish_alphabet.h
+++ b/src/common/nanopolish_alphabet.h
@@ -262,9 +262,9 @@ struct DNAAlphabet : public Alphabet
     // no methylation in this alphabet
     virtual size_t num_recognition_sites() const { return 0; }
     virtual size_t recognition_length() const { return 0; }
-    virtual const char* get_recognition_site(size_t i) const { return NULL; }
-    virtual const char* get_recognition_site_methylated(size_t i) const { return NULL; }
-    virtual const char* get_recognition_site_methylated_complement(size_t i) const { 
+    virtual const char* get_recognition_site(size_t) const { return NULL; }
+    virtual const char* get_recognition_site_methylated(size_t) const { return NULL; }
+    virtual const char* get_recognition_site_methylated_complement(size_t) const { 
         return NULL;
     }
 

--- a/src/common/nanopolish_fast5_map.cpp
+++ b/src/common/nanopolish_fast5_map.cpp
@@ -29,7 +29,7 @@ Fast5Map::Fast5Map(const std::string& fasta_filename)
     struct stat fofn_file_s;
     struct stat fasta_file_s;
     int fofn_ret = stat(fofn_filename.c_str(), &fofn_file_s);
-    int fasta_ret = stat(fasta_filename.c_str(), &fasta_file_s);
+    stat(fasta_filename.c_str(), &fasta_file_s);
 
     // Use the stored fofn if its available and newer than the fasta
     if(fofn_ret == 0 && fofn_file_s.st_mtime > fasta_file_s.st_mtime) {

--- a/src/common/nanopolish_fast5_map.cpp
+++ b/src/common/nanopolish_fast5_map.cpp
@@ -19,7 +19,7 @@
 //
 #define FOFN_SUFFIX ".fast5.fofn"
 
-KSEQ_INIT(gzFile, gzread);
+KSEQ_INIT(gzFile, gzread)
 
 Fast5Map::Fast5Map(const std::string& fasta_filename)
 {

--- a/src/common/nanopolish_iupac.h
+++ b/src/common/nanopolish_iupac.h
@@ -25,6 +25,6 @@ namespace IUPAC
     // Returns a string defining the possible unambiguous bases for each symbol
     // in the alphabet
     std::string getPossibleSymbols(char c);
-};
+}
 
 #endif

--- a/src/common/nanopolish_variant.h
+++ b/src/common/nanopolish_variant.h
@@ -58,7 +58,7 @@ struct Variant
         assert(!ref_name.empty());
         assert(!ref_seq.empty());
         assert(!alt_seq.empty());
-        assert(ref_position >= 0);
+        //assert(ref_position >= 0);
         assert(quality >= 0.0f);
     }
 

--- a/src/common/progress.h
+++ b/src/common/progress.h
@@ -15,7 +15,7 @@ class Progress
 {
     public:
         
-        Progress(const std::string message) : m_message(message), m_os(std::cerr)
+        Progress(const std::string message) : m_os(std::cerr), m_message(message)
         {
 #if HAVE_CLOCK_GETTIME            
             timespec start;

--- a/src/common/progress.h
+++ b/src/common/progress.h
@@ -31,8 +31,8 @@ class Progress
         {
 
             // print 
-            int max_leader = 40;
-            int bar_width = 50;
+            unsigned max_leader = 40;
+            unsigned bar_width = 50;
 
             std::string leader;
             if(m_message.size() > max_leader) {
@@ -43,13 +43,13 @@ class Progress
             
             m_os << leader << " [";
             
-            int pos = bar_width * progress;
-            for (int i = 0; i < bar_width; ++i) {
+            unsigned pos = bar_width * progress;
+            for (unsigned i = 0; i < bar_width; ++i) {
                 if (i < pos) m_os << "=";
                 else if (i == pos) m_os << ">";
                 else m_os << " ";
             }
-            m_os << "] " << int(progress * 100.0) << "% in " << get_elapsed_seconds() << "s\r";
+            m_os << "] " << unsigned(progress * 100.0) << "% in " << get_elapsed_seconds() << "s\r";
             m_os.flush();
         }
         

--- a/src/hmm/nanopolish_emissions.h
+++ b/src/hmm/nanopolish_emissions.h
@@ -93,7 +93,7 @@ inline float log_probability_match(const SquiggleRead& read,
         float stdv = read.get_stdv(event_idx, strand);
         float log_stdv = read.get_log_stdv(event_idx, strand);
         float lp_stdv = log_invgauss_pdf(stdv, log_stdv, state);
-        lp += log_invgauss_pdf(stdv, log_stdv, state);
+        lp += lp_stdv;
     }
 
 #if DEBUG_HMM_EMISSION
@@ -114,9 +114,9 @@ inline float log_probability_event_insert(const SquiggleRead& read,
     return log_probability_match(read, kmer_rank, event_idx, strand, scale, log_scale);
 }
 
-inline float log_probability_background(const SquiggleRead& read,
-                                        uint32_t event_idx,
-                                        uint8_t strand)
+inline float log_probability_background(const SquiggleRead&,
+                                        uint32_t,
+                                        uint8_t)
 {
     return -3.0f;
 }

--- a/src/hmm/nanopolish_hmm_input_sequence.h
+++ b/src/hmm/nanopolish_hmm_input_sequence.h
@@ -23,8 +23,8 @@ class HMMInputSequence
     
         // constructors
         HMMInputSequence(const std::string& seq) : 
-                             m_seq(seq),
-                             m_alphabet(&gDNAAlphabet)
+                             m_alphabet(&gDNAAlphabet),
+                             m_seq(seq)
         {
             m_rc_seq = m_alphabet->reverse_complement(seq);
         }
@@ -32,9 +32,9 @@ class HMMInputSequence
         HMMInputSequence(const std::string& fwd,
                          const std::string& rc,
                          const Alphabet* alphabet) : 
+                             m_alphabet(alphabet),
                              m_seq(fwd),
-                             m_rc_seq(rc),
-                             m_alphabet(alphabet)
+                             m_rc_seq(rc)
         {
 
         }

--- a/src/hmm/nanopolish_profile_hmm.cpp
+++ b/src/hmm/nanopolish_profile_hmm.cpp
@@ -28,9 +28,9 @@ void profile_hmm_forward_initialize(FloatMatrix& fm)
 // Terminate the forward algorithm by calculating
 // the probability of transitioning to the end state
 // for all columns and a given row
-float profile_hmm_forward_terminate(const FloatMatrix& fm,
-                                    const FloatMatrix& tm,
-                                    uint32_t row)
+float profile_hmm_forward_terminate(const FloatMatrix&,
+                                    const FloatMatrix&,
+                                    uint32_t)
 {
     assert(false);
     return -INFINITY;

--- a/src/hmm/nanopolish_profile_hmm.inl
+++ b/src/hmm/nanopolish_profile_hmm.inl
@@ -138,6 +138,8 @@ class ProfileHMMViterbiOutput
                 from = PS_KMER_SKIP;
             else if(max == s)
                 from = PS_PRE_SOFT;
+            else // should not be reached, but silences uninitialized warnings
+                from = 0;
             set(*p_bm, row, col, from);
         }
         

--- a/src/hmm/nanopolish_profile_hmm.inl
+++ b/src/hmm/nanopolish_profile_hmm.inl
@@ -81,7 +81,7 @@ class ProfileHMMForwardOutput
         }
 
         // add in the probability of ending the alignment at row,col
-        inline void update_end(float v, uint32_t row, uint32_t col)
+        inline void update_end(float v, uint32_t, uint32_t)
         {
             lp_end = add_logs(lp_end, v);
         }
@@ -262,7 +262,7 @@ inline std::vector<float> make_post_flanking(const HMMInputData& data,
 template<class ProfileHMMOutput>
 inline float profile_hmm_fill_generic(const HMMInputSequence& _sequence,
                                       const HMMInputData& _data,
-                                      const uint32_t _e_start,
+                                      const uint32_t,
                                       uint32_t flags,
                                       ProfileHMMOutput& output)
 {

--- a/src/hmm/nanopolish_transition_parameters.cpp
+++ b/src/hmm/nanopolish_transition_parameters.cpp
@@ -226,7 +226,9 @@ void TransitionParameters::add_training_from_alignment(const HMMInputSequence& s
     const uint32_t k = pm.k;
 
     size_t n_kmers = sequence.length() - k + 1;
+#ifdef PRINT_TRAINING_MESSAGES
     uint32_t strand_idx = 0;
+#endif
     char prev_s = 'M';
 
     for(size_t pi = 0; pi < alignment.size(); ++pi) {
@@ -273,17 +275,17 @@ void TransitionParameters::add_training_from_alignment(const HMMInputSequence& s
             add_transition_observation(prev_s, s);
 
             // emission
-            float level = data.read->get_drift_corrected_level(ei, data.strand);
-            float sd = data.read->events[data.strand][ei].stdv;
-            float duration = data.read->get_duration(ei, data.strand);
+            //float level = data.read->get_drift_corrected_level(ei, data.strand);
+            //float sd = data.read->events[data.strand][ei].stdv;
+            //float duration = data.read->get_duration(ei, data.strand);
             if(ki >= n_kmers)
                 printf("%zu %d %d %zu %.2lf %c\n", pi, ei, ki, n_kmers, alignment[pi].l_fm, s);
             
             assert(ki < n_kmers);
-            uint32_t rank = sequence.get_kmer_rank(ki, k, data.rc);
+            //uint32_t rank = sequence.get_kmer_rank(ki, k, data.rc);
         
-            GaussianParameters model = pm.get_scaled_parameters(rank);
-            float norm_level = (level - model.mean) / model.stdv;
+            //GaussianParameters model = pm.get_scaled_parameters(rank);
+            //float norm_level = (level - model.mean) / model.stdv;
 
             prev_s = s;
         }

--- a/src/hmm/nanopolish_transition_parameters.cpp
+++ b/src/hmm/nanopolish_transition_parameters.cpp
@@ -23,8 +23,8 @@ TransitionParameters::TransitionParameters()
 
     //
     allocate_matrix(td.state_transitions, 3, 3);
-    for(int i = 0; i < td.state_transitions.n_rows; ++i) {
-        for(int j = 0; j < td.state_transitions.n_cols; ++j) {
+    for(unsigned i = 0; i < td.state_transitions.n_rows; ++i) {
+        for(unsigned j = 0; j < td.state_transitions.n_cols; ++j) {
             set(td.state_transitions, i, j, 0);
         }
     }
@@ -312,7 +312,7 @@ void TransitionParameters::train()
     double p_me_not_k = (double)me / sum_m_not_k;
 
     size_t sum_e = 0;
-    for(int j = 0; j < td.state_transitions.n_cols; ++j) {
+    for(unsigned j = 0; j < td.state_transitions.n_cols; ++j) {
         sum_e += get(td.state_transitions, statechar2index('E'), j);
     }
     

--- a/src/hmm/nanopolish_transition_parameters.h
+++ b/src/hmm/nanopolish_transition_parameters.h
@@ -91,7 +91,7 @@ class TransitionParameters
         void initialize_sqkmap006_complement();
 
         // Not allowed
-        TransitionParameters(const TransitionParameters& other) {}
+        TransitionParameters(const TransitionParameters&) {}
 
         // Calculate which bin of the skip probability table this level difference falls in
         inline size_t get_skip_bin(double k_level1, double k_level2) const

--- a/src/main/nanopolish.cpp
+++ b/src/main/nanopolish.cpp
@@ -31,7 +31,7 @@ static std::map< std::string, std::function<int(int, char**)> > programs = {
     {"scorereads",  scorereads_main} 
 };
 
-int print_usage(int argc, char **argv)
+int print_usage(int, char **)
 {
     std::cout << "usage: nanopolish [command] [options]" << std::endl;
     std::cout << "  valid commands: " << std::endl;

--- a/src/nanopolish_call_variants.cpp
+++ b/src/nanopolish_call_variants.cpp
@@ -419,4 +419,5 @@ int call_variants_main(int argc, char** argv)
     if(out_fp != stdout) {
         fclose(out_fp);
     }
+    return 0;
 }

--- a/src/nanopolish_call_variants.cpp
+++ b/src/nanopolish_call_variants.cpp
@@ -207,8 +207,8 @@ std::vector<Variant> get_variants_from_vcf(const std::string& filename,
         Variant v(line);
 
         if(v.ref_name == contig &&
-           v.ref_position >= region_start &&
-           v.ref_position <= region_end) 
+           (int)v.ref_position >= region_start &&
+           (int)v.ref_position <= region_end) 
         {
             out.push_back(v);
         }
@@ -242,7 +242,7 @@ Haplotype call_variants_for_region(const std::string& contig, int region_start, 
     }
 
     // Step 2. Add variants to the haplotypes
-    size_t calling_span = 10;
+    int calling_span = 10;
     size_t curr_variant_idx = 0;
     while(curr_variant_idx < candidate_variants.size()) {
  

--- a/src/nanopolish_consensus.cpp
+++ b/src/nanopolish_consensus.cpp
@@ -882,4 +882,5 @@ int consensus_main(int argc, char** argv)
     if(out_fp != stdout) {
         fclose(out_fp);
     }
+    return 0;
 }

--- a/src/nanopolish_consensus.cpp
+++ b/src/nanopolish_consensus.cpp
@@ -220,7 +220,6 @@ bool sortIndexedPathScoreDesc(const IndexedPathScore& a, const IndexedPathScore&
 void score_paths(PathConsVector& paths, const std::vector<HMMInputData>& input)
 {
     PROFILE_FUNC("score_paths")
-    double MIN_FIT = INFINITY;
     size_t CULL_RATE = 5;
     double CULL_MIN_SCORE = -30.0f;
     double CULL_MIN_IMPROVED_FRACTION = 0.2f;
@@ -254,7 +253,7 @@ void score_paths(PathConsVector& paths, const std::vector<HMMInputData>& input)
             fprintf(stderr, "Scoring %d\n", ri);
         }
 
-        const HMMInputData& data = input[ri];
+        //const HMMInputData& data = input[ri];
         std::vector<IndexedPathScore> result(paths.size());
 
         // Score all paths
@@ -306,6 +305,7 @@ void score_paths(PathConsVector& paths, const std::vector<HMMInputData>& input)
     std::stable_sort(paths.begin(), paths.end(), sortPathConsScoreDesc);
 
 #if DEBUG_PATH_SELECTION
+    double MIN_FIT = INFINITY;
     for(size_t pi = 0; pi < paths.size(); ++pi) {
 
         // Calculate the length of the matching prefix with the initial sequence

--- a/src/nanopolish_consensus.cpp
+++ b/src/nanopolish_consensus.cpp
@@ -340,7 +340,7 @@ void extend_paths(PathConsVector& paths, int maxk = 2)
 
     for(int k = 1; k <= maxk; ++k) {
 
-        for(int pi = 0; pi < paths.size(); ++pi) {
+        for(unsigned pi = 0; pi < paths.size(); ++pi) {
     
             std::string first(k, 'A');
             std::string extension = first;

--- a/src/nanopolish_consensus.cpp
+++ b/src/nanopolish_consensus.cpp
@@ -540,7 +540,7 @@ void filter_outlier_data(std::vector<HMMInputData>& input, const std::string& se
             fprintf(stderr, "OUTLIER_FILTER %d %.2lf %.2lf %.2lf\n", ri, curr, n_events, lp_per_event);
         }
 
-        double threshold = model_stdv() ? 7.0f : 3.5f;
+        double threshold = model_stdv() ? 7.0f : 3.5f; // TODO: check
         if(fabs(lp_per_event) < 7.0f) {
             out_rs.push_back(rs);
         }

--- a/src/nanopolish_consensus.cpp
+++ b/src/nanopolish_consensus.cpp
@@ -596,7 +596,7 @@ void run_splice_segment(HMMRealignmentInput& window, uint32_t segment_id, const 
     std::vector<HMMInputData> data = get_input_for_columns(window, start_column, end_column);
 
     if(opt::verbose > 0) {
-        fprintf(stderr, "correcting segment %zu with %zu reads\n", segment_id, data.size());
+        fprintf(stderr, "correcting segment %u with %zu reads\n", segment_id, data.size());
     }
     
     // The current consensus sequence

--- a/src/nanopolish_getmodel.cpp
+++ b/src/nanopolish_getmodel.cpp
@@ -120,4 +120,5 @@ int getmodel_main(int argc, char** argv)
             gDNAAlphabet.lexicographic_next(kmer); // advance kmer
         }
     }
+    return 0;
 }

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -122,15 +122,15 @@ namespace opt
     static TrainingTarget training_target = TT_METHYLATED_KMERS;
     static bool write_models = true;
     static bool output_scores = false;
-    static int progress = 0;
-    static int num_threads = 1;
-    static int batch_size = 128;
+    static unsigned progress = 0;
+    static unsigned num_threads = 1;
+    static unsigned batch_size = 128;
 
     // Constants that determine which events to use for training
     static float min_event_duration = 0.005;
-    static int min_distance_from_alignment_end = 5;
-    static int min_number_of_events_to_train = 100;
-    static int num_training_rounds = 5;
+    static unsigned min_distance_from_alignment_end = 5;
+    static unsigned min_number_of_events_to_train = 100;
+    static unsigned num_training_rounds = 5;
 }
 
 static const char* shortopts = "r:b:g:t:m:vnc";

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -318,7 +318,7 @@ void add_aligned_events(const ModelMap& model_map,
             return;
 
         // Update pore model based on alignment
-        double orig_score;
+        double orig_score = -INFINITY;
         if (opt::output_scores) {
             orig_score = model_score(sr, strand_idx, fai, alignment_output, 500);
             #pragma omp critical(print)

--- a/src/nanopolish_poremodel.cpp
+++ b/src/nanopolish_poremodel.cpp
@@ -18,7 +18,7 @@ void PoreModel::bake_gaussian_parameters()
     scaled_params.resize(states.size());
     scaled_states.resize(states.size());
 
-    for(int i = 0; i < states.size(); ++i) {
+    for(unsigned i = 0; i < states.size(); ++i) {
 
         // as per ONT documents
         scaled_states[i].level_mean = states[i].level_mean * scale + shift;
@@ -40,7 +40,7 @@ void PoreModel::bake_gaussian_parameters()
 
 void add_found_bases(char *known, const char *kmer) {
     char newbase[2];
-    int posn;
+    unsigned posn;
     newbase[1] = '\0';
 
     while ( (posn = strspn(kmer, known)) != strlen(kmer) ){
@@ -57,7 +57,7 @@ PoreModel::PoreModel(const std::string filename, const Alphabet *alphabet) : is_
     std::string model_line;
 
     bool firstKmer = true;
-    int ninserted = 0;
+    unsigned ninserted = 0;
 
     shift_offset = 0.0f;
 

--- a/src/nanopolish_poremodel.cpp
+++ b/src/nanopolish_poremodel.cpp
@@ -50,7 +50,7 @@ void add_found_bases(char *known, const char *kmer) {
     return;
 }
 
-PoreModel::PoreModel(const std::string filename, const Alphabet *alphabet) : pmalphabet(alphabet), is_scaled(false)
+PoreModel::PoreModel(const std::string filename, const Alphabet *alphabet) : is_scaled(false), pmalphabet(alphabet)
 {
     model_filename = filename;
     std::ifstream model_reader(filename);

--- a/src/nanopolish_poremodel.h
+++ b/src/nanopolish_poremodel.h
@@ -59,7 +59,7 @@ struct PoreModelStateParams
 class PoreModel
 {
     public:
-        PoreModel(uint32_t _k=5) : is_scaled(false), k(_k), pmalphabet(&gDNAAlphabet) {}
+        PoreModel(uint32_t _k=5) : k(_k), is_scaled(false), pmalphabet(&gDNAAlphabet) {}
 
         // These constructors and the output routine take an alphabet 
         // so that kmers are inserted/written in order

--- a/src/nanopolish_scorereads.cpp
+++ b/src/nanopolish_scorereads.cpp
@@ -384,5 +384,6 @@ int scorereads_main(int argc, char** argv)
     fai_destroy(fai);
     sam_close(bam_fh);
     hts_idx_destroy(bam_idx);
+    return 0;
 }
 

--- a/src/nanopolish_scorereads.cpp
+++ b/src/nanopolish_scorereads.cpp
@@ -132,7 +132,7 @@ double model_score(SquiggleRead &sr,
         std::string ref_seq = get_reference_region_ts(fai, contig.c_str(), ref_start_pos, 
                                                       ref_end_pos, &fetched_len);
 
-        if (fetched_len <= sr.pore_model[strand_idx].k)
+        if (fetched_len <= (int)sr.pore_model[strand_idx].k)
             continue;
 
         const Alphabet *alphabet = sr.pore_model[strand_idx].pmalphabet;

--- a/src/nanopolish_scorereads.cpp
+++ b/src/nanopolish_scorereads.cpp
@@ -175,7 +175,7 @@ std::vector<EventAlignment> alignment_from_read(SquiggleRead& sr,
     }        
 
     // set k
-    uint32_t k = sr.pore_model[strand_idx].k;
+    //uint32_t k = sr.pore_model[strand_idx].k;
 
     // Align to the new model
     EventAlignmentParameters params;

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -198,8 +198,8 @@ hack:
                 }
                 erfb.indices[si].stop = incoming_idx;
 
-                assert(erfb.indices[si].start < events[si].size());
-                assert(erfb.indices[si].stop < events[si].size());
+                assert(erfb.indices[si].start < (int)events[si].size());
+                assert(erfb.indices[si].stop < (int)events[si].size());
             }
         }
         //printf("\t[%d %d] [%d %d]\n", erfb.indices[0].start, erfb.indices[0].stop, erfb.indices[1].start, erfb.indices[1].stop);

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -116,8 +116,8 @@ void SquiggleRead::load_from_fast5(const std::string& fast5_path)
             events[si][ei] = { static_cast<float>(f5_event.mean), 
                                static_cast<float>(f5_event.stdv), 
                                static_cast<float>(f5_event.start), 
-                               static_cast<float>(f5_event.length) };
-            events[si][ei].log_stdv = log(events[si][ei].stdv);
+                               static_cast<float>(f5_event.length),
+                               static_cast<float>(log(f5_event.stdv)) };
         }
     }
 

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -190,7 +190,7 @@ hack:
                 uint32_t incoming_idx = si == 0 ? eae.template_index : eae.complement_index;
                 
                 // no event for this strand, nothing to update
-                if(incoming_idx == -1)
+                if(incoming_idx == -1) // TODO: check this
                     continue;
 
                 if(erfb.indices[si].start == -1) {

--- a/src/nanopolish_squiggle_read.h
+++ b/src/nanopolish_squiggle_read.h
@@ -156,7 +156,7 @@ class SquiggleRead
 
     private:
         
-        SquiggleRead(const SquiggleRead& other) {}
+        SquiggleRead(const SquiggleRead&) {}
 
         // helper for get_closest_event_to
         int get_next_event(int start, int stop, int stride, uint32_t strand) const;

--- a/src/test/nanopolish_test.cpp
+++ b/src/test/nanopolish_test.cpp
@@ -371,7 +371,7 @@ generate_training_data(const ParamMixture& mixture, size_t n_data,
         // draw population
         size_t j = discrete_dist(weights.begin(), weights.end())(rg);
         ++population_size[j];
-        assert(0 <= j and j < n_components);
+        assert(j < n_components);
         // draw read_var
         data[i].read_var = uniform_dist(read_var_rg[0], read_var_rg[1])(rg);
         data[i].log_read_var = std::log(data[i].read_var);


### PR DESCRIPTION
Cleaned up a variety of warnings. Most fall into one of: unused variable, incorrect constructor initialization order, signed vs unsigned comparison. Left a couple of TODOs where the original intent was unclear.