### PR TITLE
Update Dockerfile make invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ RUN yum group install "Development Tools" -y
 RUN yum install git wget tar zlib-devel -y
 RUN git clone --recursive https://github.com/jts/nanopolish.git
 WORKDIR /nanopolish
-RUN make libhdf5.install nanopolish
+RUN make all
 CMD ./nanopolish


### PR DESCRIPTION
`libhdf5.install` no longer exists as a target.   Addresses issue #47 .