### PR TITLE
Add capability to recalibrate holding drift=0

### DIFF
--- a/src/alignment/nanopolish_anchor.cpp
+++ b/src/alignment/nanopolish_anchor.cpp
@@ -89,7 +89,7 @@ HMMRealignmentInput build_input_for_region(const std::string& bam_filename,
             std::vector<EventAlignment> ao = alignment_from_read(sr, strand_idx, -1,
                                                                  "", fai, hdr,
                                                                  record, -1, -1);
-            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, true);
+            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, true, true);
         }
 
         k = sr.pore_model[T_IDX].k;

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -263,7 +263,9 @@ bool recalibrate_model(SquiggleRead &sr,
     if (scale_var) {
         double var = 0.;
         for (size_t i=0; i<raw_events.size(); i++) {
-            double yi = (raw_events[i] - shift - scale*level_means[i] - drift*times[i]);
+            double yi = (raw_events[i] - shift - scale*level_means[i]);
+            if (scale_drift)
+                yi -= drift*times[i];
             var+= yi*yi/(level_stdvs[i]*level_stdvs[i]);
         }
         var /= raw_events.size();

--- a/src/nanopolish_methyltrain.h
+++ b/src/nanopolish_methyltrain.h
@@ -21,7 +21,8 @@ bool recalibrate_model(SquiggleRead &sr,
                        const int strand_idx,
                        const std::vector<EventAlignment> &alignment_output,
                        const Alphabet* alphabet,
-                       bool scale_var);
+                       bool scale_var=true,
+                       bool scale_drift=true);
 
 int methyltrain_main(int argc, char** argv);
 

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -205,7 +205,7 @@ void SquiggleRead::load_from_fast5(const std::string& fast5_path, const uint32_t
         }
 
         std::vector<EventAlignment> alignment = get_eventalignment_for_basecalls(5, si);
-        bool calibrated = recalibrate_model(*this, si, alignment, pore_model[si].pmalphabet, true);
+        bool calibrated = recalibrate_model(*this, si, alignment, pore_model[si].pmalphabet, true, true);
 
         if(!calibrated) {
             events[si].clear();

--- a/src/nanopolish_train_poremodel_from_basecalls.cpp
+++ b/src/nanopolish_train_poremodel_from_basecalls.cpp
@@ -318,7 +318,7 @@ int train_poremodel_from_basecalls_main(int argc, char** argv)
                               training_strand,
                               filtered_alignment,
                               &gDNAAlphabet,
-                              false);
+                              false, true);
         
             const PoreModel& read_model = read->pore_model[training_strand];
             printf("[recalibration] read %zu events: %zu alignment: %zu shift: %.2lf scale: %.2lf drift: %.4lf var: %.2lf\n", 


### PR DESCRIPTION
A new argument is added to `recalibrate_model`, `scale_drift`; if false, only the two equations for scale and shift are solved, and the model drift is set to zero.  As before, the var is recalculated if the `scale_var` option is set.    Sample output from 20 reads is shown below; this is the output of scorereads without recalibration, with recalibration with drift allowed to - well - drift; and with drift head to zero (`nanopolish scorereads -z`).  

```
#read                                                strand      model                                no_recalib  drift     drift=0
74f196d1-79b1-4f95-bc85-556ea3fd1103_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -4.24859    -4.23368  -4.23347
74f196d1-79b1-4f95-bc85-556ea3fd1103_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -4.4335     -4.43344  -4.43038
890d5665-065c-4989-a504-97360f394797_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -4.37701    -4.36775  -4.36776
890d5665-065c-4989-a504-97360f394797_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -4.37236    -4.36813  -4.36951
b4411ee0-5792-4ed1-9cb7-c9d5eb697666_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -4.57109    -4.55259  -4.55328
b4411ee0-5792-4ed1-9cb7-c9d5eb697666_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -4.35806    -4.3587   -4.35831
94f84f7a-e625-4b57-8531-7a63bcf730c2_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -4.1253     -4.1167   -4.11675
94f84f7a-e625-4b57-8531-7a63bcf730c2_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -3.7        -3.43947  -3.44041
cfe23418-3f4e-46ec-b56c-f54b8b5d13bf_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -3.67172    -3.67802  -3.67525
cfe23418-3f4e-46ec-b56c-f54b8b5d13bf_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -3.87516    -3.80198  -3.80236
86bceb89-437d-4ca1-ac75-6ec3304a73c2_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -3.2359     -3.23546  -3.23508
86bceb89-437d-4ca1-ac75-6ec3304a73c2_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -3.87957    -3.80286  -3.80601
1728e3d1-e257-47dd-8271-0fad5b5c7b61_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -3.35842    -3.3575   -3.37605
1728e3d1-e257-47dd-8271-0fad5b5c7b61_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -3.86848    -3.79484  -3.79543
cb0fc2d3-cf92-45d4-a62a-2bb072663d94_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -3.44349    -3.44036  -3.44074
cb0fc2d3-cf92-45d4-a62a-2bb072663d94_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -3.971      -3.88061  -3.88268
d32be6a9-a55a-422c-a8a1-35e2a36109df_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -3.51565    -3.51673  -3.52001
d32be6a9-a55a-422c-a8a1-35e2a36109df_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -4.38664    -4.29946  -4.30457
d1add053-faed-4097-bc6d-ee7817158438_Basecall_2D_2d  template    template_median68pA.model.dropmodel  -3.09503    -3.09479  -3.09496
d1add053-faed-4097-bc6d-ee7817158438_Basecall_2D_2d  complement  template_median68pA.model.dropmodel  -3.11194    -3.10402  -3.10407
```