### PR TITLE
Calculate L1 residual when recalibrating model, return it as a parameter

### DIFF
--- a/src/alignment/nanopolish_anchor.cpp
+++ b/src/alignment/nanopolish_anchor.cpp
@@ -89,7 +89,8 @@ HMMRealignmentInput build_input_for_region(const std::string& bam_filename,
             std::vector<EventAlignment> ao = alignment_from_read(sr, strand_idx, -1,
                                                                  "", fai, hdr,
                                                                  record, -1, -1);
-            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, true, true);
+            double resid = 0.;
+            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, resid, true, true);
         }
 
         k = sr.pore_model[T_IDX].k;

--- a/src/nanopolish_methyltrain.h
+++ b/src/nanopolish_methyltrain.h
@@ -16,11 +16,13 @@
 #include "nanopolish_squiggle_read.h"
 
 // recalculate shift, scale, drift, scale_sd from an alignment and the read
-// returns true if the recalibration was performed
+// returns the L1 residual of the recalibrated model
+// sets residual parameter to L1 norm of the residual
 bool recalibrate_model(SquiggleRead &sr,
                        const int strand_idx,
                        const std::vector<EventAlignment> &alignment_output,
                        const Alphabet* alphabet,
+                       double &residual,
                        bool scale_var=true,
                        bool scale_drift=true);
 

--- a/src/nanopolish_scorereads.cpp
+++ b/src/nanopolish_scorereads.cpp
@@ -505,7 +505,8 @@ int scorereads_main(int argc, char** argv)
 
                         // Update pore model based on alignment
                         if( opt::calibrate ) {
-                            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, false, opt::scale_drift);
+                            double resid=0.;
+                            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, resid, false, opt::scale_drift);
                         }
 
                         if(opt::learn_model_offset) {

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -198,6 +198,7 @@ void SquiggleRead::load_from_fast5(const std::string& fast5_path, const uint32_t
 
     // Calibrate the models using the basecalls
     for(size_t si = 0; si < 2; ++si) {
+        double resid = 0.;
 
         // only recalibrate if there is a model, its a 2D read or a 2D read and the right strand
         if( !(read_type == SRT_2D || read_type == si) || (flags & SRF_NO_MODEL) ) {
@@ -205,7 +206,7 @@ void SquiggleRead::load_from_fast5(const std::string& fast5_path, const uint32_t
         }
 
         std::vector<EventAlignment> alignment = get_eventalignment_for_basecalls(5, si);
-        bool calibrated = recalibrate_model(*this, si, alignment, pore_model[si].pmalphabet, true, true);
+        bool calibrated = recalibrate_model(*this, si, alignment, pore_model[si].pmalphabet, resid, true, true);
 
         if(!calibrated) {
             events[si].clear();

--- a/src/nanopolish_train_poremodel_from_basecalls.cpp
+++ b/src/nanopolish_train_poremodel_from_basecalls.cpp
@@ -314,10 +314,12 @@ int train_poremodel_from_basecalls_main(int argc, char** argv)
             }
 
             // recalibrate shift/scale/etc using the filtered alignment
+            double resid = 0.;
             recalibrate_model(*read, 
                               training_strand,
                               filtered_alignment,
                               &gDNAAlphabet,
+                              resid, 
                               false, true);
         
             const PoreModel& read_model = read->pore_model[training_strand];


### PR DESCRIPTION
Calculating and returning the L1 residual as part of `recalibrate_model()`.  I don't love having it as a separate parameter which has to be passed in invocations that don't need it, but the alternatives look messy - do the same thing with the bool about whether the recalibration happened, return a special residual value to specify bool=false (which I hate) or return a pair.

I'm not 100% sure what the right metric for the residual is - the L2 norm is just `var`, so I think var-scaled L1 norm seems right - it's a measure of the distance the means are off rather than just the spreads.  But that will take some experimentation.