### PR TITLE
Calculate L1 residual when recalibrating model, return it as a parameter

### DIFF
--- a/src/alignment/nanopolish_alignment_db.cpp
+++ b/src/alignment/nanopolish_alignment_db.cpp
@@ -431,7 +431,8 @@ void AlignmentDB::_load_events_by_region()
             fprintf(stderr, "Rescale for %s strand: %d rc: %d\n", event_record.sr->read_name.c_str(), event_record.strand, event_record.rc);
             event_record.sr->print_scaling_parameters(stderr, event_record.strand);
             fprintf(stderr, "recal events: %zu\n", event_alignment.size());
-            recalibrate_model(*event_record.sr, event_record.strand, event_alignment, &gDNAAlphabet, true, false);
+            double resid = 0.;
+            recalibrate_model(*event_record.sr, event_record.strand, event_alignment, &gDNAAlphabet, resid, true, false);
             event_record.sr->print_scaling_parameters(stderr, event_record.strand);
         }
 

--- a/src/alignment/nanopolish_anchor.cpp
+++ b/src/alignment/nanopolish_anchor.cpp
@@ -89,7 +89,8 @@ HMMRealignmentInput build_input_for_region(const std::string& bam_filename,
             std::vector<EventAlignment> ao = alignment_from_read(sr, strand_idx, -1,
                                                                  "", fai, hdr,
                                                                  record, -1, -1);
-            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, true, true);
+            double resid = 0.;
+            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, resid, true, true);
         }
 
         k = sr.pore_model[T_IDX].k;

--- a/src/nanopolish_methyltrain.h
+++ b/src/nanopolish_methyltrain.h
@@ -17,10 +17,12 @@
 
 // recalculate shift, scale, drift, scale_sd from an alignment and the read
 // returns true if the recalibration was performed
+// in either case, sets residual to the L1 norm of the residual
 bool recalibrate_model(SquiggleRead &sr,
                        const int strand_idx,
                        const std::vector<EventAlignment> &alignment_output,
                        const Alphabet* alphabet,
+                       double &residual,
                        bool scale_var=true,
                        bool scale_drift=true);
 

--- a/src/nanopolish_scorereads.cpp
+++ b/src/nanopolish_scorereads.cpp
@@ -178,7 +178,7 @@ double model_score(SquiggleRead &sr,
         double resid = 0.;
         recalibrate_model(sr, strand_idx, event_alignment_sub, &gDNAAlphabet, resid, true, opt::scale_drift);
 
-        fprintf(stdout, "SEGMENT\t%s\t%d\t%.3lf\t%d\t%.2lf\t%.2lf\t%.2lf\t%.2lf\n", 
+        fprintf(stdout, "SEGMENT\t%s\t%zu\t%.3lf\t%d\t%.2lf\t%.2lf\t%.2lf\t%.2lf\n", 
                     sr.read_name.c_str(), 
                     nevents, 
                     segment_score / events_in_segment, 

--- a/src/nanopolish_scorereads.cpp
+++ b/src/nanopolish_scorereads.cpp
@@ -175,7 +175,8 @@ double model_score(SquiggleRead &sr,
         double curr_drift = sr.pore_model[strand_idx].drift;
         double curr_var = sr.pore_model[strand_idx].var;
             
-        recalibrate_model(sr, strand_idx, event_alignment_sub, &gDNAAlphabet, true, opt::scale_drift);
+        double resid = 0.;
+        recalibrate_model(sr, strand_idx, event_alignment_sub, &gDNAAlphabet, resid, true, opt::scale_drift);
 
         fprintf(stdout, "SEGMENT\t%s\t%d\t%.3lf\t%d\t%.2lf\t%.2lf\t%.2lf\t%.2lf\n", 
                     sr.read_name.c_str(), 
@@ -538,7 +539,8 @@ int scorereads_main(int argc, char** argv)
 
                         // Update pore model based on alignment
                         if( opt::calibrate ) {
-                            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, true, opt::scale_drift);
+                            double residual = 0.;
+                            recalibrate_model(sr, strand_idx, ao, &gDNAAlphabet, residual, true, opt::scale_drift);
                         }
 
                         if(opt::learn_model_offset) {

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -206,7 +206,8 @@ void SquiggleRead::load_from_fast5(const std::string& fast5_path, const uint32_t
             filtered.push_back(ea);
         }
 
-        bool calibrated = recalibrate_model(*this, si, filtered, pore_model[si].pmalphabet, true, false);
+        double residual = 0.;
+        bool calibrated = recalibrate_model(*this, si, filtered, pore_model[si].pmalphabet, residual, true, false);
         if(!calibrated) {
             events[si].clear();
         }

--- a/src/nanopolish_train_poremodel_from_basecalls.cpp
+++ b/src/nanopolish_train_poremodel_from_basecalls.cpp
@@ -320,10 +320,12 @@ int train_poremodel_from_basecalls_main(int argc, char** argv)
             }
 
             // recalibrate shift/scale/etc using the filtered alignment
+            double resid = 0.;
             recalibrate_model(*read, 
                               training_strand,
                               filtered_alignment,
                               &gDNAAlphabet,
+                              resid, 
                               false, true);
         
             const PoreModel& read_model = read->pore_model[training_strand];


### PR DESCRIPTION
Calculating and returning the L1 residual as part of recalibrate_model(). I don't love having it as a separate parameter which has to be passed in invocations that don't need it, but the alternatives look messy - do the same thing with the bool about whether the recalibration happened, return a special residual value to specify bool=false (which I hate) or return a pair.

I'm not 100% sure what the right metric for the residual is - the L2 norm is just var, so I think var-scaled L1 norm seems right - it's a measure of the distance the means are off rather than just the spreads. But that will take some experimentation.
