### PR TITLE
Fast5 update

### DIFF
--- a/src/alignment/nanopolish_alignment_db.cpp
+++ b/src/alignment/nanopolish_alignment_db.cpp
@@ -576,7 +576,7 @@ void AlignmentDB::_debug_print_alignments()
         int event_middle_start, event_middle_end;
         _find_by_ref_bounds(record.aligned_events, ref_middle, ref_middle, event_middle_start, event_middle_end);
         AlignedPair last = record.aligned_events.back();
-        printf("event_record[%zu] name: %s strand: %zu stride: %d rc: %zu align bounds [%d %d] [%d %d] [%d %d]\n", 
+        printf("event_record[%zu] name: %s strand: %d stride: %d rc: %d align bounds [%d %d] [%d %d] [%d %d]\n", 
                 i,
                 record.sr->read_name.c_str(),
                 record.strand,

--- a/src/common/logger.hpp
+++ b/src/common/logger.hpp
@@ -1,50 +1,66 @@
-//-----------------------------------------------
-// Copyright 2013 Ontario Institute for Cancer Research
-// Written by Matei David (mdavid@oicr.on.ca)
-// Released under the MIT license
-//-----------------------------------------------
+/// Part of: https://github.com/mateidavid/hpptools
+/// Commit: 5a6f39c
 
-// Logger mechanism
-//
-// Properties:
-// - thread-safe, non-garbled output (uses c++11's thread_local)
-// - customizable ostream sink. by default, uses std::clog
-//
-// Main exports:
-// - "Logger" class
-// - "level_wrapper" namespace
-// - "LOG" macro
-//
-// To use:
-// - In source code, use:
-//
-//     LOG(info) << "hello" << endl;
-//     // or 
-//     LOG("main", info) << "hello" << endl;
-//     // or 
-//     LOG("main", info, sink_os) << "hello" << endl;
-//
-//   Here, "main" is the facility (a string) and info is the message level.
-//   Note that "logger" is a macro which knows how to look up the name info
-//   inside level_wrapper. The macro introduces C++ code equivalent to:
-//
-//     if (...message should be ignored...) then; else sink_os
-//
-//   NOTE: As with assert(), the code in the output stream following the
-//   logger() macro will ***not be executed*** if the log level of the
-//   facility is higher than the level of the message.
-//
-// - To set the default log level (for unspecified facilities):
-//
-//     Logger::set_default_level(Logger::level_from_string(s));
-//
-// - To set the log level for the "main" facility:
-//
-//     Logger::set_facility_level("main", Logger::level_from_string(s));
-//
-// - By using these functions, one can set log levels using command-line
-//   parameters and achieve dynamic log level settings without recompiling.
-
+/// @author    Matei David, Ontario Institute for Cancer Research
+/// @version   1.0
+/// @date      2013-2017
+/// @copyright MIT Public License
+///
+/// Logger mechanism.
+///
+/// Properties:
+/// - thread-safe, non-garbled output (uses c++11's thread_local)
+/// - customizable ostream sink. by default, uses std::clog
+///
+/// Exports:
+/// - macro: LOG (takes 1, 2, or 3 arguments, see below)
+/// - macros: LOG_EXIT_, LOG_ABORT, LOG_EXIT, LOG_THROW_, and LOG_THROW
+/// - namespace logger
+/// - enum logger::level
+/// - class logger::Logger
+///
+/// To use:
+/// - In source code, use:
+///
+///     LOG(info) << "hello" << endl;
+///     // or 
+///     LOG("main", info) << "hello" << endl;
+///     // or 
+///     LOG("main", info, sink_os) << "hello" << endl;
+///
+///   Here, "main" is the facility (a string) and info is the message level.
+///   Note that "logger" is a macro which knows how to look up the name info
+///   inside logger namespace. The macro introduces C++ code equivalent to:
+///
+///     if (...message should be ignored...) then; else sink_os
+///
+///   NOTE: As with assert(), the code in the output stream following the
+///   LOG() macro will ***not be executed*** if the log level of the
+///   facility is higher than the level of the message.
+///
+/// - To set the default log level (for unspecified facilities):
+///
+///     logger::Logger::set_default_level(logger::Logger::level_from_string(s));
+///
+/// - To set the log level for the "main" facility:
+///
+///     logger::Logger::set_facility_level("main", logger::Logger::level_from_string(s));
+///
+/// - To parse a log facility level setting in the form "[<facility>:]<level>":
+///
+///     logger::Logger::set_level_from_option("alt:debug1", &cerr);
+///
+/// - By using these functions, one can set log levels using command-line
+///   parameters and achieve dynamic log level settings without recompiling.
+///
+/// - The macros LOG_EXIT_, LOG_ABORT, LOG_EXIT, LOG_THROW_, and LOG_THROW
+///   provide a way to specify what to do after logging the message.
+///
+///     LOG_EXIT_(exit_code)  << "print this message to std::cerr, call std::exit(exit_code)";
+///     LOG_ABORT             << "print this message to std::cerr, call std::abort()";
+///     LOG_EXIT              << "print this message to std::cerr, call std::exit(EXIT_FAILURE)";
+///     LOG_THROW_(Exception) << "throw Exception with this message";
+///     LOG_THROW             << "throw std::runtime_error with this message";
 
 #ifndef __LOGGER_HPP
 #define __LOGGER_HPP
@@ -55,43 +71,75 @@
 #include <sstream>
 #include <iostream>
 #include <mutex>
+#include <stdexcept>
 
-namespace level_wrapper
+namespace logger
 {
-    // log levels
-    enum level
-    {
-        error = 0,
-        warning,
-        info,
-        debug,
-        debug1,
-        debug2
-    };
-}
+
+// log levels
+enum level
+{
+    error = 0,
+    warning,
+    info,
+    debug,
+    debug1,
+    debug2
+};
 
 class Logger
-    : public std::ostringstream
 {
 public:
-    typedef level_wrapper::level level;
     // Constructor: initialize buffer.
-    Logger(const std::string& facility, level msg_level,
-           const std::string& file_name, unsigned line_num, const std::string& func_name,
-           std::ostream& os = std::clog)
+    Logger(std::string const & facility, level msg_level,
+           std::string const & file_name, unsigned line_num, std::string const & func_name,
+           std::ostream & os = std::clog)
         : _os_p(&os)
     {
-        *this << "= " << facility << "." << int(msg_level)
-              << " " << file_name << ":" << line_num
-              << " " << func_name << " ";
+        _oss << "= " << facility << "." << int(msg_level)
+             << " " << file_name << ":" << line_num << " " << func_name << " ";
+        _on_destruct = [&] () {
+            _os_p->write(_oss.str().c_str(), _oss.str().size());
+        };
+    }
+    // Constructor for exiting
+    Logger(int exit_code,
+           std::string const & file_name, unsigned line_num, std::string const & func_name,
+           std::ostream & os = std::cerr)
+        : _os_p(&os), _exit_code(exit_code)
+    {
+        _oss << file_name << ":" << line_num << " " << func_name << " ";
+        _on_destruct = [&] () {
+            _os_p->write(_oss.str().c_str(), _oss.str().size());
+            if (_exit_code < 0)
+            {
+                std::abort();
+            }
+            else
+            {
+                std::exit(_exit_code);
+            }
+        };
+    }
+    // Constructor for throwing exceptions
+    // first argument is only used to deduce the template argument type
+    template <typename Exception>
+    Logger(Exception const &,
+           std::string const & file_name, unsigned line_num, std::string const & func_name,
+           typename std::enable_if<std::is_base_of<std::exception, Exception>::value>::type * = 0)
+    {
+        _oss << file_name << ":" << line_num << " " << func_name << " ";
+        _on_destruct = [&] () {
+            throw Exception(_oss.str());
+        };
     }
     // Destructor: dump buffer to output.
-    ~Logger()
+    ~Logger() noexcept(false)
     {
-        _os_p->write(this->str().c_str(), this->str().size());
+        _on_destruct();
     }
     // Produce l-value for output chaining.
-    std::ostream& l_value() { return *this; }
+    std::ostream & l_value() { return _oss; }
 
     // static methods for setting and getting facility log levels.
     static level get_default_level()
@@ -101,38 +149,38 @@ public:
     static void set_default_level(level l)
     {
         static std::mutex m;
-        std::lock_guard< std::mutex > lg(m);
+        std::lock_guard<std::mutex> lg(m);
         default_level() = l;
     }
     static void set_default_level(int l)
     {
         set_default_level(get_level(l));
     }
-    static void set_default_level(const std::string& s)
+    static void set_default_level(std::string const & s)
     {
         set_default_level(get_level(s));
     }
-    static level get_facility_level(const std::string& facility)
+    static level get_facility_level(std::string const & facility)
     {
         return (facility_level_map().count(facility) > 0?
                 facility_level_map().at(facility) : get_default_level());
     }
-    static void set_facility_level(const std::string& facility, level l)
+    static void set_facility_level(std::string const & facility, level l)
     {
         static std::mutex m;
-        std::lock_guard< std::mutex > lg(m);
+        std::lock_guard<std::mutex> lg(m);
         facility_level_map()[facility] = l;
     }
-    static void set_facility_level(const std::string& facility, int l)
+    static void set_facility_level(std::string const & facility, int l)
     {
         set_facility_level(facility, get_level(l));
     }
-    static void set_facility_level(const std::string& facility, const std::string& s)
+    static void set_facility_level(std::string const & facility, std::string const & s)
     {
         set_facility_level(facility, get_level(s));
     }
     // static methods for setting log levels from command-line options
-    static void set_level_from_option(const std::string& l, std::ostream* os_p = nullptr)
+    static void set_level_from_option(std::string const & l, std::ostream * os_p = nullptr)
     {
         size_t i = l.find(':');
         if (i == std::string::npos)
@@ -141,7 +189,7 @@ public:
             if (os_p)
             {
                 (*os_p) << "set default log level to: "
-                        << static_cast< int >(Logger::get_default_level()) << std::endl;
+                        << static_cast<int>(Logger::get_default_level()) << std::endl;
             }
         }
         else
@@ -150,44 +198,46 @@ public:
             if (os_p)
             {
                 (*os_p) << "set log level of '" << l.substr(0, i) << "' to: "
-                        << static_cast< int >(Logger::get_facility_level(l.substr(0, i))) << std::endl;
+                        << static_cast<int>(Logger::get_facility_level(l.substr(0, i))) << std::endl;
             }
         }
     }
-    static void set_levels_from_options(const std::vector< std::string >& v, std::ostream* os_p = nullptr)
+    static void set_levels_from_options(std::vector<std::string> const & v, std::ostream * os_p = nullptr)
     {
-        for (const auto& l : v)
+        for (auto const & l : v)
         {
             set_level_from_option(l, os_p);
         }
     }
     // public static utility functions (used by LOG macro)
     static level get_level(level l) { return l; }
-    static level get_level(int i) { return static_cast< level >(i); }
-    static level get_level(const std::string& s) { return level_from_string(s); }
+    static level get_level(int i) { return static_cast<level>(i); }
+    static level get_level(std::string const & s) { return level_from_string(s); }
     // public static member (used by LOG macro)
     static level& thread_local_last_level()
     {
-        static thread_local level _last_level = level_wrapper::error;
+        static thread_local level _last_level = error;
         return _last_level;
     }
 private:
-    // sink for this Logger object
-    std::ostream* _os_p;
+    std::ostringstream _oss;
+    std::function<void()> _on_destruct;
+    std::ostream * _os_p;
+    int _exit_code;
 
     // private static data members
-    static level& default_level()
+    static level & default_level()
     {
-        static level _default_level = level_wrapper::error;
+        static level _default_level = error;
         return _default_level;
     }
-    static std::map< std::string, level >& facility_level_map()
+    static std::map<std::string, level> & facility_level_map()
     {
-        static std::map< std::string, level > _facility_level_map;
+        static std::map<std::string, level> _facility_level_map;
         return _facility_level_map;
     }
     // private static utility functions
-    static level level_from_string(const std::string& s)
+    static level level_from_string(std::string const & s)
     {
         std::istringstream iss(s + "\n");
         int tmp_int = -1;
@@ -198,20 +248,23 @@ private:
         }
         else
         {
-            if (s == "error") return level_wrapper::error;
-            else if (s == "warning") return level_wrapper::warning;
-            else if (s == "info") return level_wrapper::info;
-            else if (s == "debug") return level_wrapper::debug;
-            else if (s == "debug1") return level_wrapper::debug1;
-            else if (s == "debug2") return level_wrapper::debug2;
+            if (s == "error") return logger::error;
+            else if (s == "warning") return logger::warning;
+            else if (s == "info") return logger::info;
+            else if (s == "debug") return logger::debug;
+            else if (s == "debug1") return logger::debug1;
+            else if (s == "debug2") return logger::debug2;
             else
             {
-                std::cerr << "could not parse log level: " << s << "\n";
-                std::exit(1);
+                std::ostringstream oss;
+                oss << "could not parse log level: " << s;
+                throw std::invalid_argument(oss.str());
             }
         }
     }
 }; // class Logger
+
+} //namespace logger
 
 #define __FILENAME__ (std::string(__FILE__).find('/') != std::string::npos? std::string(__FILE__).substr(std::string(__FILE__).rfind('/') + 1) : std::string(__FILE__))
 
@@ -230,18 +283,18 @@ private:
  * Log to `facility` at logger level `level_spec` and dump output to `sink`.
  * If sink is omitted, it defaults to std::clog.
  * If `facility` is omitted (logger has single argument), the macro LOG_FACILITY
- * is used instead.
+ * is used instead, defaulting to "main".
  */
 
 #define __LOG_3(facility, level_spec, sink)                                   \
-    { using namespace level_wrapper; Logger::thread_local_last_level() = Logger::get_level(level_spec); } \
-    if (Logger::thread_local_last_level() > Logger::get_facility_level(facility)) ; \
-    else Logger(facility, Logger::thread_local_last_level(), __FILENAME__, __LINE__, __func__, sink).l_value()
+    { using namespace logger; logger::Logger::thread_local_last_level() = logger::Logger::get_level(level_spec); } \
+    if (logger::Logger::thread_local_last_level() > logger::Logger::get_facility_level(facility)) ; \
+    else logger::Logger(facility, logger::Logger::thread_local_last_level(), __FILENAME__, __LINE__, __func__, sink).l_value()
 
 #define __LOG_2(facility, level_spec)                                   \
-    { using namespace level_wrapper; Logger::thread_local_last_level() = Logger::get_level(level_spec); } \
-    if (Logger::thread_local_last_level() > Logger::get_facility_level(facility)) ; \
-    else Logger(facility, Logger::thread_local_last_level(), __FILENAME__, __LINE__, __func__).l_value()
+    { using namespace logger; logger::Logger::thread_local_last_level() = logger::Logger::get_level(level_spec); } \
+    if (logger::Logger::thread_local_last_level() > logger::Logger::get_facility_level(facility)) ; \
+    else logger::Logger(facility, logger::Logger::thread_local_last_level(), __FILENAME__, __LINE__, __func__).l_value()
 
 #define __LOG_1(level_spec) \
     __LOG_2(LOG_FACILITY, level_spec)
@@ -249,12 +302,77 @@ private:
 // we need 2-level indirection in order to trigger expansion after token pasting
 // http://stackoverflow.com/questions/1597007/creating-c-macro-with-and-line-token-concatenation-with-positioning-macr
 // http://stackoverflow.com/a/11763196/717706
+#ifdef WIN32
+#define __EXPAND(...) __VA_ARGS__
+#define __LOG_aux2(N, ...) __EXPAND(__LOG_ ## N (__VA_ARGS__))
+#else
 #define __LOG_aux2(N, ...) __LOG_ ## N (__VA_ARGS__)
+#endif
+
 #define __LOG_aux1(N, ...) __LOG_aux2(N, __VA_ARGS__)
 
 #define __NARGS_AUX(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, ...) _9
+
+#ifdef WIN32
+#define __NARGS(...) __EXPAND(__NARGS_AUX(__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0))
+#else
 #define __NARGS(...) __NARGS_AUX(__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0)
+#endif
+
+#ifndef LOG_FACILITY
+#define LOG_FACILITY "main"
+#endif
 
 #define LOG(...) __LOG_aux1(__NARGS(__VA_ARGS__), __VA_ARGS__)
+
+#define LOG_EXIT_(exit_code) logger::Logger((exit_code), __FILENAME__, __LINE__, __func__).l_value()
+#define LOG_ABORT LOG_EXIT_(-1)
+#define LOG_EXIT LOG_EXIT_(EXIT_FAILURE)
+
+#define LOG_THROW_(Exception) logger::Logger(Exception(""), __FILENAME__, __LINE__, __func__).l_value()
+#define LOG_THROW LOG_THROW_(std::runtime_error)
+
+#endif
+
+#ifdef SAMPLE_LOGGER
+
+/*
+
+Compile:
+
+g++ -std=c++11 -D SAMPLE_LOGGER -x c++ logger.hpp -o sample-logger
+
+Run:
+./sample-logger info
+./sample-logger info alt:debug1
+
+*/
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+    if (argc < 2)
+    {
+        cerr << "Use: " << argv[0] << " <log_level_setting> ..." << endl
+             << "The program sends 5 log messages with decreasing priority (0=highest, 4=lowest)" << endl
+             << "to 2 facilities \"main\" and \"alt\". Command-line arguments are interpreted as" << endl
+             << "log facility level settings in the form [<facility>:]<level>." << endl;
+        return EXIT_FAILURE;
+    }
+    for (int i = 1; i < argc; ++i)
+    {
+        cerr << "processing argument [" << argv[i] << "]" << endl;
+        logger::Logger::set_level_from_option(argv[i], &cerr);
+    }
+    vector<string> const level_name{ "error", "warning", "info", "debug", "debug1", "debug2" };
+    for (int l = 0; l < 5; ++l)
+    {
+        LOG(level_name[l]) << "message at level " << l << " (" << level_name[l]
+                           << ") for facility main" << endl;
+        LOG("alt", l) << "message at level " << l << " (" << level_name[l]
+                      << ") for facility alt" << endl;
+    }
+}
 
 #endif

--- a/src/common/nanopolish_alphabet.h
+++ b/src/common/nanopolish_alphabet.h
@@ -234,7 +234,7 @@ class Alphabet
         }
 
         // does this alphabet contain all of the nucleotides in bases?
-        virtual inline bool contains_all(const char *bases) const = 0;
+        virtual bool contains_all(const char *bases) const = 0;
 };
 
 #define BASIC_MEMBER_BOILERPLATE \

--- a/src/nanopolish_call_methylation.cpp
+++ b/src/nanopolish_call_methylation.cpp
@@ -316,7 +316,7 @@ void calculate_methylation_for_read(const OutputHandles& handles,
             fprintf(handles.site_writer, "%s\t%d\t%d\t", ss.chromosome.c_str(), ss.start_position, ss.end_position);
             fprintf(handles.site_writer, "%s\t%.2lf\t", sr.read_name.c_str(), diff);
             fprintf(handles.site_writer, "%.2lf\t%.2lf\t", sum_ll_m, sum_ll_u);
-            fprintf(handles.site_writer, "%zu\t%d\t%s\n", ss.strands_scored, ss.n_cpg, ss.sequence.c_str());
+            fprintf(handles.site_writer, "%d\t%d\t%s\n", ss.strands_scored, ss.n_cpg, ss.sequence.c_str());
         }
     }
 }

--- a/src/nanopolish_call_variants.cpp
+++ b/src/nanopolish_call_variants.cpp
@@ -403,7 +403,7 @@ void print_debug_stats(const std::string& contig,
         double base_avg = base_score / num_events;
         double called_avg = called_score / num_events;
         const PoreModel& pm = data.read->pore_model[data.strand];
-        fprintf(stats_out, "%s\t%zu\t%zu\t", data.read->read_name.c_str(), data.strand, data.rc);
+        fprintf(stats_out, "%s\t%d\t%d\t", data.read->read_name.c_str(), data.strand, data.rc);
         fprintf(stats_out, "%.2lf\t%.2lf\t\t%.2lf\t%.2lf\t%.2lf\t", base_score, called_score, base_avg, called_avg, called_score - base_score);
         fprintf(stats_out, "%.2lf\t%.2lf\t%.4lf\t%.2lf\n", pm.shift, pm.scale, pm.drift, pm.var);
 
@@ -451,7 +451,7 @@ void print_debug_stats(const std::string& contig,
 
             char diff = base_kmer != called_kmer ? 'D' : ' ';
             fprintf(alignment_out, "%s\t%zu\t%.2lf\t%.2lf\t%.4lf\t", data.read->read_name.c_str(), event_idx, event_mean, event_stdv, event_duration);
-            fprintf(alignment_out, "%c\t%c\t%zu\t%zu\t\t", base_align[bi].state, called_align[ci].state, base_align[bi].kmer_idx, called_align[ci].kmer_idx);
+            fprintf(alignment_out, "%c\t%c\t%u\t%u\t\t", base_align[bi].state, called_align[ci].state, base_align[bi].kmer_idx, called_align[ci].kmer_idx);
             fprintf(alignment_out, "%s\t%.2lf\t%s\t%.2lf\t", base_kmer.c_str(), base_model.level_mean, called_kmer.c_str(), called_model.level_mean);
             fprintf(alignment_out, "%.2lf\t%.2lf\t%c\t%.2lf\n", base_standard_level, called_standard_level, diff, sum_called_abs_sl - sum_base_abs_sl);
 
@@ -604,7 +604,7 @@ Haplotype fix_homopolymers(const Haplotype& input_haplotype,
                     duration_likelihoods[var_sequence_length] += log_gamma;
                 }
                 if(opt::verbose > 3) {
-                   fprintf(stderr, "SUM_VAR\t%zu\t%d\t%d\t%d\t%d\t%.5lf\t%.2lf\n", ref_hp_start, hp_length, var_sequence_length, call_window, variant_offset_end - variant_offset_start, sum_duration, log_gamma);
+                   fprintf(stderr, "SUM_VAR\t%zu\t%zu\t%d\t%d\t%lu\t%.5lf\t%.2lf\n", ref_hp_start, hp_length, var_sequence_length, call_window, variant_offset_end - variant_offset_start, sum_duration, log_gamma);
                 }
             }
         }

--- a/src/nanopolish_extract.cpp
+++ b/src/nanopolish_extract.cpp
@@ -35,7 +35,7 @@ static const char *EXTRACT_USAGE_MESSAGE =
 "  -v, --verbose                        display verbose output\n"
 "  -r, --recurse                        recurse into subdirectories\n"
 "  -q, --fastq                          extract fastq (default: fasta)\n"
-"  -t, --type=TYPE                      read type: template, complement, 2d, 2d-or-template, all\n"
+"  -t, --type=TYPE                      read type: template, complement, 2d, 2d-or-template, any\n"
 "                                         (default: 2d-or-template)\n"
 "  -o, --output=FILE                    write output to FILE (default: stdout)\n"
 "\nReport bugs to " PACKAGE_BUGREPORT "\n\n";
@@ -59,7 +59,7 @@ get_preferred_basecall_groups(const fast5::File& f, const std::string& read_type
     bool have_2d = false;
     std::vector< std::pair< unsigned, std::string > > res;
     // check 2d
-    if (read_type == "all"
+    if (read_type == "any"
         or read_type == "2d"
         or read_type == "2d-or-template")
     {
@@ -72,7 +72,7 @@ get_preferred_basecall_groups(const fast5::File& f, const std::string& read_type
             {
                 have_2d = true;
                 res.push_back(std::make_pair(2, gr));
-                if (read_type != "all")
+                if (read_type != "any")
                 {
                     break;
                 }
@@ -82,7 +82,7 @@ get_preferred_basecall_groups(const fast5::File& f, const std::string& read_type
     // check 1d
     for (unsigned st = 0; st < 2; ++st)
     {
-        if (opt::read_type == "all"
+        if (opt::read_type == "any"
             or (st == 0
                 and (opt::read_type == "template"
                      or (not have_2d and opt::read_type == "2d-or-template")))
@@ -96,7 +96,7 @@ get_preferred_basecall_groups(const fast5::File& f, const std::string& read_type
                     and f.have_basecall_events(st, gr))
                 {
                     res.push_back(std::make_pair(st, gr));
-                    if (read_type != "all")
+                    if (read_type != "any")
                     {
                         break;
                     }
@@ -295,7 +295,7 @@ void parse_extract_options(int argc, char** argv)
              or opt::read_type == "complement"
              or opt::read_type == "2d"
              or opt::read_type == "2d-or-template"
-             or opt::read_type == "all"))
+             or opt::read_type == "any"))
     {
         std::cerr << SUBPROGRAM ": invalid read type: " << opt::read_type << "\n";
         die = true;

--- a/src/nanopolish_extract.cpp
+++ b/src/nanopolish_extract.cpp
@@ -4,6 +4,12 @@
 //---------------------------------------------------------
 //
 
+//
+// Getopt
+//
+#define SUBPROGRAM "extract"
+#define LOG_FACILITY SUBPROGRAM
+
 #include <iostream>
 #include <sstream>
 #include <getopt.h>
@@ -13,12 +19,6 @@
 #include "fs_support.hpp"
 #include "logger.hpp"
 #include "alg.hpp"
-
-//
-// Getopt
-//
-#define SUBPROGRAM "extract"
-#define LOG_FACILITY SUBPROGRAM
 
 static const char *EXTRACT_VERSION_MESSAGE =
 SUBPROGRAM " Version " PACKAGE_VERSION "\n"
@@ -272,9 +272,9 @@ void parse_extract_options(int argc, char** argv)
         }
     }
     // set log levels
-    auto default_level = (int)level_wrapper::warning + opt::verbose;
-    Logger::set_default_level(default_level);
-    Logger::set_levels_from_options(log_level, &std::clog);
+    auto default_level = (int)logger::warning + opt::verbose;
+    logger::Logger::set_default_level(default_level);
+    logger::Logger::set_levels_from_options(log_level, &std::clog);
     // parse paths to process
     while (optind < argc)
     {

--- a/src/nanopolish_methyltrain.cpp
+++ b/src/nanopolish_methyltrain.cpp
@@ -485,7 +485,7 @@ void parse_methyltrain_options(int argc, char** argv)
                 std::cout << METHYLTRAIN_VERSION_MESSAGE;
                 exit(EXIT_SUCCESS);
             case OPT_LOG_LEVEL:
-                Logger::set_level_from_option(arg.str());
+                logger::Logger::set_level_from_option(arg.str());
                 break;
         }
     }

--- a/src/nanopolish_phase_reads.cpp
+++ b/src/nanopolish_phase_reads.cpp
@@ -210,7 +210,7 @@ void phase_single_read(const Fast5Map& name_map,
     upper_search.ref_position = alignment_end_pos;
     auto upper_iter = std::upper_bound(variants.begin(), variants.end(), upper_search, sortByPosition);
 
-    fprintf(stderr, "%s %s:%zu-%zu %zu\n", read_name.c_str(), ref_name.c_str(), alignment_start_pos, alignment_end_pos, upper_iter - lower_iter);
+    fprintf(stderr, "%s %s:%u-%u %zu\n", read_name.c_str(), ref_name.c_str(), alignment_start_pos, alignment_end_pos, upper_iter - lower_iter);
 
     // no variants to phase?
     if(lower_iter == variants.end()) {

--- a/src/nanopolish_phase_reads.cpp
+++ b/src/nanopolish_phase_reads.cpp
@@ -130,7 +130,7 @@ void parse_phase_reads_options(int argc, char** argv)
                 std::cout << PHASE_READS_VERSION_MESSAGE;
                 exit(EXIT_SUCCESS);
             case OPT_LOG_LEVEL:
-                Logger::set_level_from_option(arg.str());
+                logger::Logger::set_level_from_option(arg.str());
                 break;
         }
     }

--- a/src/nanopolish_poremodel.cpp
+++ b/src/nanopolish_poremodel.cpp
@@ -177,13 +177,13 @@ PoreModel::PoreModel(fast5::File *f_p, const size_t strand, const std::string& b
 
     std::map<std::string, PoreModelStateParams> kmers;
 
-    std::vector<fast5::Model_Entry> model = f_p->get_basecall_model(strand, bc_gr);
+    auto model = f_p->get_basecall_model(strand, bc_gr);
     k = array2str(model[0].kmer).length();
     assert(k == 5 || k == 6);
 
     // Copy into the pore model for this read
     for(size_t mi = 0; mi < model.size(); ++mi) {
-        const fast5::Model_Entry& curr = model[mi];
+        auto const & curr = model[mi];
 
         std::string stringkmer = array2str(curr.kmer);
         assert(stringkmer.size() == k);
@@ -203,7 +203,7 @@ PoreModel::PoreModel(fast5::File *f_p, const size_t strand, const std::string& b
     }
 
     // Load the scaling parameters for the pore model
-    fast5::Model_Parameters params = f_p->get_basecall_model_params(strand, bc_gr);
+    auto params = f_p->get_basecall_model_params(strand, bc_gr);
     drift = params.drift;
     scale = params.scale;
     scale_sd = params.scale_sd;

--- a/src/nanopolish_poremodel.h
+++ b/src/nanopolish_poremodel.h
@@ -50,7 +50,7 @@ struct PoreModelStateParams
         update_logs();
     }
 
-    PoreModelStateParams& operator =(const fast5::Model_Entry& e)
+    PoreModelStateParams& operator =(const fast5::Basecall_Model_State& e)
     {
         level_mean = e.level_mean;
         level_stdv = e.level_stdv;

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -104,14 +104,14 @@ void SquiggleRead::load_from_fast5(const uint32_t flags)
         }
 
         // Load the events for this strand
-        std::vector<fast5::Event_Entry> f5_events = f_p->get_basecall_events(si, basecall_group);
+        auto f5_events = f_p->get_basecall_events(si, basecall_group);
 
         // copy events
         events[si].resize(f5_events.size());
         std::vector<double> p_model_states;
 
         for(size_t ei = 0; ei < f5_events.size(); ++ei) {
-            const fast5::Event_Entry& f5_event = f5_events[ei];
+            auto const & f5_event = f5_events[ei];
 
             events[si][ei] = { static_cast<float>(f5_event.mean),
                                static_cast<float>(f5_event.stdv),
@@ -130,7 +130,7 @@ void SquiggleRead::load_from_fast5(const uint32_t flags)
 
         // NB we use event_group in this call rather than basecall_group as we want the 1D basecalls that match the events
         read_sequences_1d[si] = f_p->get_basecall_seq(si == 0 ? SRT_TEMPLATE : SRT_COMPLEMENT,
-                                                      f_p->get_basecall_group_1d(basecall_group));
+                                                      f_p->get_basecall_1d_group(basecall_group));
         event_maps_1d[si] = build_event_map_1d(read_sequences_1d[si], si, f5_events);
 
         // run version-specific load
@@ -170,7 +170,7 @@ void SquiggleRead::load_from_fast5(const uint32_t flags)
         sample_start_time = f_p->get_raw_samples_params(sample_read_name).start_time;
 
         // retreive parameters
-        fast5::Channel_Id_Parameters channel_params = f_p->get_channel_id_params();
+        auto channel_params = f_p->get_channel_id_params();
         sample_rate = channel_params.sampling_rate;
     }
 
@@ -358,7 +358,7 @@ void SquiggleRead::_load_R9(uint32_t si,
 
 std::vector<EventRangeForBase> SquiggleRead::build_event_map_1d(const std::string& read_sequence_1d,
                                                                 uint32_t strand,
-                                                                std::vector<fast5::Event_Entry>& f5_events)
+                                                                std::vector<fast5::Basecall_Event>& f5_events)
 {
     assert(f_p and f_p->is_open());
     std::vector<EventRangeForBase> out_event_map;
@@ -376,7 +376,7 @@ std::vector<EventRangeForBase> SquiggleRead::build_event_map_1d(const std::strin
 
     size_t curr_k_idx = 0;
     for(size_t ei = 1; ei < f5_events.size(); ++ei) {
-        const fast5::Event_Entry& f5_event = f5_events[ei];
+        auto const & f5_event = f5_events[ei];
 
         // Calculate the number of kmers to move along the basecalled sequence
         // We do not use the value provided in the fast5 due to an albacore bug.
@@ -424,7 +424,7 @@ void SquiggleRead::build_event_map_2d_r9()
     //
     // Build the map from read k-mers to events
     //
-    std::vector<fast5::Event_Alignment_Entry> event_alignments = f_p->get_basecall_event_alignment(basecall_group);
+    auto event_alignments = f_p->get_basecall_alignment(basecall_group);
     assert(!read_sequence.empty());
 
     // R9 change: use k from the event table as this might not match the pore model
@@ -470,7 +470,7 @@ void SquiggleRead::build_event_map_2d_r9()
         EventRangeForBase& erfb =  base_to_event_map[read_kidx];
         for(uint32_t i = start_ea_idx; i < end_ea_idx; ++i) {
 
-            fast5::Event_Alignment_Entry& eae = event_alignments[i];
+            auto const & eae = event_alignments[i];
 
             for(uint32_t si = 0; si <= 1; ++si) {
                 int incoming_idx = si == 0 ? eae.template_index : eae.complement_index;
@@ -505,7 +505,7 @@ void SquiggleRead::build_event_map_2d_r7()
     //
     // Build the map from read k-mers to events
     //
-    std::vector<fast5::Event_Alignment_Entry> event_alignments = f_p->get_basecall_event_alignment(basecall_group);
+    auto event_alignments = f_p->get_basecall_alignment(basecall_group);
     assert(!read_sequence.empty());
 
     const uint32_t k = pore_model[T_IDX].k;
@@ -563,7 +563,7 @@ hack:
         EventRangeForBase& erfb =  base_to_event_map[read_kidx];
         for(uint32_t i = start_ea_idx; i < end_ea_idx; ++i) {
 
-            fast5::Event_Alignment_Entry& eae = event_alignments[i];
+            auto const & eae = event_alignments[i];
 
             for(uint32_t si = 0; si <= 1; ++si) {
                 uint32_t incoming_idx = si == 0 ? eae.template_index : eae.complement_index;

--- a/src/nanopolish_squiggle_read.h
+++ b/src/nanopolish_squiggle_read.h
@@ -230,7 +230,7 @@ class SquiggleRead
         // make a map from a base of the 1D read sequence to the range of events supporting that base
         std::vector<EventRangeForBase> build_event_map_1d(const std::string& read_sequence_1d,
                                                           uint32_t strand, 
-                                                          std::vector<fast5::Event_Entry>& f5_events);
+                                                          std::vector<fast5::Basecall_Event>& f5_events);
 
         // as above but for the 2D sequence. this fills in both the template and complete event indices
         void build_event_map_2d_r7();


### PR DESCRIPTION
- Updated code to use Fast5 0.6+, which contains built-in packing. Nanopolish should now be able to run directly on packed files.
- Fixed various `printf` format warnings.
- Fixed warning about inline pure virtual.
- Renamed `extract` option from `all` to `any` addressing #116.