### PR TITLE
Ability to increase the number of tested haplotypes on the command line

### DIFF
--- a/src/common/nanopolish_variant.cpp
+++ b/src/common/nanopolish_variant.cpp
@@ -150,6 +150,10 @@ void score_variant_group(VariantGroup& variant_group,
     }
     max_r -= 1;
 
+    if(max_r != num_variants) {
+        fprintf(stderr, "Number of variants in span (%d) would exceed max-haplotypes. Variants may be missed. Consider running with a higher value of max-haplotypes!\n", num_variants);
+    }
+
     // Construct haplotypes (including the base haplotype with no variants)
     // Track the variant combination ID within the group
     std::vector<std::pair<Haplotype, size_t>> haplotypes;

--- a/src/nanopolish_call_variants.cpp
+++ b/src/nanopolish_call_variants.cpp
@@ -126,7 +126,7 @@ namespace opt
     static int debug_alignments = 0;
 }
 
-static const char* shortopts = "r:b:g:t:w:o:e:m:c:d:a:v";
+static const char* shortopts = "r:b:g:t:w:o:e:m:c:d:a:v:x:";
 
 enum { OPT_HELP = 1,
        OPT_VERSION,

--- a/src/nanopolish_call_variants.cpp
+++ b/src/nanopolish_call_variants.cpp
@@ -87,6 +87,7 @@ static const char *CONSENSUS_USAGE_MESSAGE =
 "  -t, --threads=NUM                    use NUM threads (default: 1)\n"
 "  -m, --min-candidate-frequency=F      extract candidate variants from the aligned reads when the variant frequency is at least F (default 0.2)\n"
 "  -d, --min-candidate-depth=D          extract candidate variants from the aligned reads when the depth is at least D (default: 20)\n"
+"  -x, --max-haplotypes=N               consider at most N haplotype combinations (default: 1000)\n"
 "  -c, --candidates=VCF                 read variant candidates from VCF, rather than discovering them from aligned reads\n"
 "  -a, --alternative-basecalls-bam=FILE if an alternative basecaller was used that does not output event annotations\n"
 "                                       then use basecalled sequences from FILE. The signal-level events will still be taken from the -b bam.\n"
@@ -153,6 +154,7 @@ static const struct option longopts[] = {
     { "threads",                   required_argument, NULL, 't' },
     { "min-candidate-frequency",   required_argument, NULL, 'm' },
     { "min-candidate-depth",       required_argument, NULL, 'd' },
+    { "max-haplotypes",            required_argument, NULL, 'x' },
     { "candidates",                required_argument, NULL, 'c' },
     { "ploidy",                    required_argument, NULL, 'p' },
     { "alternative-basecalls-bam", required_argument, NULL, 'a' },
@@ -934,6 +936,7 @@ void parse_call_variants_options(int argc, char** argv)
             case 'o': arg >> opt::output_file; break;
             case 'm': arg >> opt::min_candidate_frequency; break;
             case 'd': arg >> opt::min_candidate_depth; break;
+            case 'x': arg >> opt::max_haplotypes; break;
             case 'c': arg >> opt::candidates_file; break;
             case 'p': arg >> opt::ploidy; break;
             case 'a': arg >> opt::alternative_basecalls_bam; break;


### PR DESCRIPTION
Hi Jared

As discussed, here is a patch for nanopolish that:
* produces a warning if nanopolish variants skips over a dense block of candidate variants because the number of haplotypes to test is too high
* allows the max-haplotypes parameter to be set on the command line

Cheers
Nick
