### PR TITLE
logger.cpp - gcc 7 - <functional>

### DIFF
--- a/src/common/logger.hpp
+++ b/src/common/logger.hpp
@@ -72,6 +72,7 @@
 #include <iostream>
 #include <mutex>
 #include <stdexcept>
+#include <functional>
 
 namespace logger
 {


### PR DESCRIPTION
Fixing compilerer error about "'function' in namespace 'std' not naming a template type".
With Debian having transitioned to version 7 of the gcc/g++, this patch came rather natural ;) No idea about compatibility with gcc6.