### PR TITLE
fprintf on size_t: %d -> %ul

### DIFF
--- a/src/common/nanopolish_variant.cpp
+++ b/src/common/nanopolish_variant.cpp
@@ -175,7 +175,7 @@ void score_variant_group(VariantGroup& variant_group,
     max_r -= 1;
 
     if(max_r != num_variants) {
-        fprintf(stderr, "Number of variants in span (%d) would exceed max-haplotypes. Variants may be missed. Consider running with a higher value of max-haplotypes!\n", num_variants);
+        fprintf(stderr, "Number of variants in span (%lu) would exceed max-haplotypes. Variants may be missed. Consider running with a higher value of max-haplotypes!\n", num_variants);
     }
 
     // Construct haplotypes (including the base haplotype with no variants)

--- a/src/nanopolish_haplotype.cpp
+++ b/src/nanopolish_haplotype.cpp
@@ -169,7 +169,7 @@ size_t Haplotype::_find_derived_index_by_ref_lower_bound(size_t ref_index) const
 
 void Haplotype::print_debug_info() const
 {
-    fprintf(stderr, "[haplotype-debug] ctg: %s, position: %d\n", m_ref_name.c_str(), m_ref_position);
+    fprintf(stderr, "[haplotype-debug] ctg: %s, position: %lu\n", m_ref_name.c_str(), m_ref_position);
     fprintf(stderr, "[haplotype-debug] r-sequence: %s\n", m_reference.c_str());
     fprintf(stderr, "[haplotype-debug] h-sequence: %s\n", m_sequence.c_str());
     for(size_t i = 0; i < m_variants.size(); ++i) {


### PR DESCRIPTION
Hello,

I just updated the Debian package of nanopolish to 0.8.1 and these warnings scrolling along the screen somehow felt bad. Please apologize for not patching something more important. That said, we all anticipate positions of the size of a full genome which at least for the human exceeds the maximal position of a signed int, so this patch may eventually turn out to important after all :)

Please ping me if the Debian Linux distribution can do something else for you.

Kind regards,

Steffen
