### PR TITLE
Avoid comparison of char* and string literal

### DIFF
--- a/src/hmm/nanopolish_profile_hmm.cpp
+++ b/src/hmm/nanopolish_profile_hmm.cpp
@@ -32,8 +32,8 @@ float profile_hmm_score(const HMMInputSequence& sequence, const HMMInputData& da
 float profile_hmm_score_set(const std::vector<HMMInputSequence>& sequences, const HMMInputData& data, const uint32_t flags)
 {
     assert(!sequences.empty());
-    assert(sequences[0].get_alphabet()->get_name() == "nucleotide");
-    assert(data.pore_model->pmalphabet->get_name() == "nucleotide");
+    assert(std::string(sequences[0].get_alphabet()->get_name()) == "nucleotide");
+    assert(std::string(data.pore_model->pmalphabet->get_name()) == "nucleotide");
     
     HMMInputData alt_data = data;
     size_t num_models = sequences.size();


### PR DESCRIPTION
It looks like Alphabet->get_name() was recently changed from a std::string to a char*, which was causing the following runtime error for me:

nanopolish: src/hmm/nanopolish_profile_hmm.cpp:40: float profile_hmm_score_set(const std::vector<HMMInputSequence>&, const HMMInputData&, uint32_t): Assertion `sequences[0].get_alphabet()->get_name() == "nucleotide"' failed.

Not sure if the cast is the desired solution.