### PR TITLE
Patch for building with system htslib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SUBDIRS := src src/hmm src/thirdparty src/thirdparty/scrappie src/common src/ali
 #
 
 #Basic flags every build needs
-LIBS=-lz
+LIBS=-lz -lgomp
 CXXFLAGS ?= -g -O3
 CXXFLAGS += -std=c++11 -fopenmp -fsigned-char
 CFLAGS ?= -O3 -std=c99

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ ifeq ($(HTS), install)
     HTS_INCLUDE=-I./htslib
 else
     # Use system-wide htslib
-    HTS_LIB=-lhts
+	HTS_LIB=
+	HTS_INCLUDE=
+    LIBS += -lhts
 endif
 
 # Include the header-only fast5 library


### PR DESCRIPTION
Hi,

I've patched the `Makefile` to fix an error I came across when building against a system install of htslib 1.6 (actually a Conda package build). The first commit addresses this:

````
make: *** No rule to make target `-lhts', needed by `nanopolish'. Stop.
````

The second commit addresses this:

````
src/nanopolish_call_variants.o: In function `call_variants_main(int, char**)':
nanopolish_call_variants.cpp:(.text+0x57b6): undefined reference to `omp_set_num_threads'
src/nanopolish_methyltrain.o: In function `methyltrain_main(int, char**)':
nanopolish_methyltrain.cpp:(.text+0x3d84): undefined reference to `omp_set_num_threads'
src/nanopolish_phase_reads.o: In function `phase_single_read(ReadDB const&, __faidx_t const*, std::vector<Variant, std::allocator<Variant> > const&, htsFile*, bam_hdr_t const*, bam1_t const*, unsigned long, int, int)':
nanopolish_phase_reads.cpp:(.text+0x569): undefined reference to `omp_get_thread_num'
src/nanopolish_phase_reads.o: In function `phase_reads_main(int, char**)':
nanopolish_phase_reads.cpp:(.text+0x11ca): undefined reference to `omp_set_num_threads'
src/nanopolish_scorereads.o: In function `scorereads_main(int, char**)':
nanopolish_scorereads.cpp:(.text+0xf23): undefined reference to `omp_set_num_threads'
src/common/nanopolish_bam_processor.o: In function `BamProcessor::parallel_run(std::function<void (bam_hdr_t const*, bam1_t const*, unsigned long, int, int)>)':
nanopolish_bam_processor.cpp:(.text+0x3c5): undefined reference to `omp_get_num_threads'
nanopolish_bam_processor.cpp:(.text+0x3d9): undefined reference to `omp_set_num_threads'
nanopolish_bam_processor.cpp:(.text+0x62b): undefined reference to `omp_set_num_threads'
src/alignment/nanopolish_eventalign.o: In function `eventalign_main(int, char**)':
nanopolish_eventalign.cpp:(.text+0x2bf6): undefined reference to `omp_set_num_threads'
make: *** [nanopolish] Error 1
````

(I also added to `CXXFLAGS` `-I$PREFIX/include/eigen3` because Eigen 3.3.4 installed itself under `eigen3` instead of `eigen`, but that's under my control).

Thanks.