### PR TITLE
fix too many open files due to a missing file close

### DIFF
--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -117,6 +117,9 @@ SquiggleRead::SquiggleRead(const std::string& name, const ReadDB& read_db, const
             this->read_sequence = read_db.get_read_sequence(read_name);
             load_from_raw(hdf5_file, flags);
         }
+        
+        fast5_close(hdf5_file);
+        
     } else {
         fprintf(stderr, "[warning] fast5 file is unreadable and will be skipped: %s\n", fast5_path.c_str());
         g_bad_fast5_file += 1;


### PR DESCRIPTION
Get a  #003: H5FDsec2.c line 343 in H5FD_sec2_open(): unable to open file: name = '..', errno = 24, error message = 'Too many open files', flags = 0, o_flags = 0 as  fast5_close is missing.
Putting  fast5_close eradicated the issue, hopefully, I have put fast5_close in the correct place.