### PR TITLE
Performance improvements to nanopolish call-methylation

### DIFF
--- a/src/alignment/nanopolish_eventalign.cpp
+++ b/src/alignment/nanopolish_eventalign.cpp
@@ -84,7 +84,7 @@ namespace opt
     static int progress = 0;
     static int num_threads = 1;
     static int scale_events = 0;
-    static int batch_size = 128;
+    static int batch_size = 512;
     static bool print_read_names;
     static bool full_output;
     static bool write_samples = false;

--- a/src/common/nanopolish_bam_processor.cpp
+++ b/src/common/nanopolish_bam_processor.cpp
@@ -98,7 +98,7 @@ void BamProcessor::parallel_run( std::function<void(const bam_hdr_t* hdr,
 
         // realign if we've hit the max buffer size or reached the end of file
         if(num_records_buffered == records.size() || result < 0 || (num_records_buffered + num_reads_realigned == m_max_reads)) {
-            #pragma omp parallel for
+            #pragma omp parallel for schedule(dynamic)
             for(size_t i = 0; i < num_records_buffered; ++i) {
                 bam1_t* record = records[i];
                 size_t read_idx = num_reads_realigned + i;

--- a/src/common/nanopolish_bam_processor.cpp
+++ b/src/common/nanopolish_bam_processor.cpp
@@ -16,10 +16,12 @@
 
 BamProcessor::BamProcessor(const std::string& bam_file,
                            const std::string& region,
-                           const int num_threads) :
+                           const int num_threads,
+                           const int batch_size) :
                             m_bam_file(bam_file),
                             m_region(region),
-                            m_num_threads(num_threads)
+                            m_num_threads(num_threads),
+                            m_batch_size(batch_size)
 
 {
     // load bam file

--- a/src/common/nanopolish_bam_processor.h
+++ b/src/common/nanopolish_bam_processor.h
@@ -21,7 +21,8 @@ class BamProcessor
     public:
         BamProcessor(const std::string& bam_filename, 
                      const std::string& region,
-                     const int num_threads);
+                     const int num_threads,
+                     const int batch_size=128);
 
         ~BamProcessor();
 

--- a/src/common/nanopolish_bam_processor.h
+++ b/src/common/nanopolish_bam_processor.h
@@ -22,7 +22,7 @@ class BamProcessor
         BamProcessor(const std::string& bam_filename, 
                      const std::string& region,
                      const int num_threads,
-                     const int batch_size=128);
+                     const int batch_size=512);
 
         ~BamProcessor();
 
@@ -46,7 +46,7 @@ class BamProcessor
         hts_idx_t* m_bam_idx;
         bam_hdr_t* m_hdr;
 
-        int m_batch_size = 128;
+        int m_batch_size = 512;
         int m_num_threads = 1;
         size_t m_max_reads = -1;
 };

--- a/src/nanopolish_call_methylation.cpp
+++ b/src/nanopolish_call_methylation.cpp
@@ -100,6 +100,7 @@ static const char *CALL_METHYLATION_USAGE_MESSAGE =
 "  -g, --genome=FILE                    the genome we are computing a consensus for is in FILE\n"
 "  -t, --threads=NUM                    use NUM threads (default: 1)\n"
 "      --progress                       print out a progress message\n"
+"  -K  --batchsize=NUM                  the batch size (default: 128)\n"
 "\nReport bugs to " PACKAGE_BUGREPORT "\n\n";
 
 namespace opt
@@ -116,7 +117,7 @@ namespace opt
     static int batch_size = 128;
 }
 
-static const char* shortopts = "r:b:g:t:w:m:vn";
+static const char* shortopts = "r:b:g:t:w:m:K:vn";
 
 enum { OPT_HELP = 1, OPT_VERSION, OPT_PROGRESS };
 
@@ -131,6 +132,7 @@ static const struct option longopts[] = {
     { "progress",         no_argument,       NULL, OPT_PROGRESS },
     { "help",             no_argument,       NULL, OPT_HELP },
     { "version",          no_argument,       NULL, OPT_VERSION },
+    { "batchsize",        no_argument,       NULL, 'K' },
     { NULL, 0, NULL, 0 }
 };
 
@@ -338,6 +340,7 @@ void parse_call_methylation_options(int argc, char** argv)
             case 'm': arg >> opt::models_fofn; break;
             case 'w': arg >> opt::region; break;
             case 'v': opt::verbose++; break;
+            case 'K': arg >> opt::batch_size ;break;
             case OPT_PROGRESS: opt::progress = true; break;
             case OPT_HELP:
                 std::cout << CALL_METHYLATION_USAGE_MESSAGE;
@@ -419,7 +422,7 @@ int call_methylation_main(int argc, char** argv)
     // bam record, read index, etc passed as parameters
     // bind the other parameters the worker function needs here
     auto f = std::bind(calculate_methylation_for_read, std::ref(handles), std::ref(read_db), fai, _1, _2, _3, _4, _5);
-    BamProcessor processor(opt::bam_file, opt::region, opt::num_threads);
+    BamProcessor processor(opt::bam_file, opt::region, opt::num_threads, opt::batch_size);
     processor.parallel_run(f);
 
     // cleanup

--- a/src/nanopolish_call_methylation.cpp
+++ b/src/nanopolish_call_methylation.cpp
@@ -100,7 +100,7 @@ static const char *CALL_METHYLATION_USAGE_MESSAGE =
 "  -g, --genome=FILE                    the genome we are computing a consensus for is in FILE\n"
 "  -t, --threads=NUM                    use NUM threads (default: 1)\n"
 "      --progress                       print out a progress message\n"
-"  -K  --batchsize=NUM                  the batch size (default: 128)\n"
+"  -K  --batchsize=NUM                  the batch size (default: 512)\n"
 "\nReport bugs to " PACKAGE_BUGREPORT "\n\n";
 
 namespace opt
@@ -114,7 +114,7 @@ namespace opt
     static std::string cpg_methylation_model_type = "reftrained";
     static int progress = 0;
     static int num_threads = 1;
-    static int batch_size = 128;
+    static int batch_size = 512;
 }
 
 static const char* shortopts = "r:b:g:t:w:m:K:vn";


### PR DESCRIPTION
1. Changing the scheduling policy in the bam processor to dynamic
2. An option for increasing the batch size in nanopolish call-methylation (new option K)
3. Changing the default batch size in nanopolish call-methylation (K) to 512

With the previous scheduling policy (static scheduling) for 8 threads.

	Percent of CPU this job got: 347%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:32.16

After changing the scheduling policy (dynamic scheduling now) for 8 threads.

	Percent of CPU this job got: 657%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 2:08.48

After adding an option to increase the batch size. Now run with K=4096 batch size for 8 threads.

	Percent of CPU this job got: 760%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:55.87


How the performance varies with the number of threads is below.
<img src="https://user-images.githubusercontent.com/12987163/36845180-cb5bf8de-1da9-11e8-907c-dfcfb3f4ad68.png" width="400">

