### PR TITLE
Forgot to call python first?

### DIFF
--- a/docs/source/quickstart_call_methylation.rst
+++ b/docs/source/quickstart_call_methylation.rst
@@ -84,7 +84,7 @@ The output file contains a lot of information including the position of the CG d
 
 A positive value in the ``log_lik_ratio`` column indicates support for methylation. We have provided a helper script that can be used to calculate how often each reference position was methylated: ::
 
-	scripts/calculate_methylation_frequency.py -i methylation_calls.tsv > methylation_frequency.tsv
+	python scripts/calculate_methylation_frequency.py -i methylation_calls.tsv > methylation_frequency.tsv
 
 The output is another tab-separated file, this time summarized by genomic position: ::
 
@@ -96,7 +96,7 @@ The output is another tab-separated file, this time summarized by genomic positi
 
 In the example data set we have also included bisulfite data from ENCODE for the same region of chromosome 20. We can use the included ``compare_methylation.py`` helper script to do a quick comparison between the nanopolish methylation output and bisulfite: ::
 
-    python compare_methylation.py bisulfite.ENCFF835NTC.example.tsv methylation_frequency.tsv > bisulfite_vs_nanopolish.tsv
+    python scripts/compare_methylation.py bisulfite.ENCFF835NTC.example.tsv methylation_frequency.tsv > bisulfite_vs_nanopolish.tsv
 
 We can use R to visualize the results - we observe good correlation between the nanopolish methylation calls and bisulfite: ::
 


### PR DESCRIPTION
I think you skipped calling `python` first when you run the first python script (_calculate_methylation_frequency.py_).
I also added `scripts/` to the command after that (when you call _compare_methylation.py_), as the user would not normally be in the scripts folder at that point.
I hope that is alright/helpful!