### PR TITLE
Use Biopython's string based FASTA parser

### DIFF
--- a/scripts/extract_reads_aligned_to_region.py
+++ b/scripts/extract_reads_aligned_to_region.py
@@ -8,7 +8,8 @@ in draft genome assembly.
 from __future__ import print_function
 
 try:
-	from Bio import SeqIO
+	from Bio.SeqIO.FastaIO import SimpleFastaParser
+        from Bio.SeqIO.QualityIO import FastqGeneralIterator
 	import pysam
 	import argparse
 	import subprocess
@@ -146,27 +147,27 @@ def main():
 		if ".gz" in file_type:
 			with gzip.open(o_fa, "rt") as fin:
 				if "fasta.gz" in file_type:
-					for record in SeqIO.parse(fin, "fasta"):
+					for title, seq in SimpleFastaParser(handle):
+						name = title.split(None, 1)[0]
 						if record.id in region_read_ids:
-							fout.write(">" + record.id + "\n")
-							fout.write(str(record.seq) + "\n")
+							fout.write(">%s\n%s\n" % (name, seq))
 				elif "fastq.gz" in file_type:
-					for record in SeqIO.parse(fin, "fastq"):
+					for title, seq, qual in FastqGeneralIterator(handle):
+						name = title.split(None, 1)[0]
 						if record.id in region_read_ids:
-							fout.write(">" + record.id + "\n")
-							fout.write(str(record.seq) + "\n")
+							fout.write(">%s\n%s\n" % (name, seq))
 		else:
 			with open(o_fa, "rt") as fin:
 				if "fasta" in file_type:
-					for record in SeqIO.parse(fin, "fasta"):
+					for title, seq in SimpleFastaParser(handle):
+						name = title.split(None, 1)[0]
 						if record.id in region_read_ids:
-							fout.write(">" + record.id + "\n")
-							fout.write(str(record.seq) + "\n")
+							fout.write(">%s\n%s\n" % (name, seq))
 				elif "fastq" in file_type:
-					for record in SeqIO.parse(fin, "fastq"):
+					for title, seq, qual in FastqGeneralIterator(handle):
+						name = title.split(None, 1)[0]
 						if record.id in region_read_ids:
-							fout.write(">" + record.id + "\n")
-							fout.write(str(record.seq) + "\n")
+							fout.write(">%s\n%s\n" % (name, seq))
 
 	# --------------------------------------------------------
 	# PART 7: 	Let's get to tarring

--- a/scripts/nanopolish_makerange.py
+++ b/scripts/nanopolish_makerange.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import sys
 import argparse
-from Bio import SeqIO
+from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 parser = argparse.ArgumentParser(description='Partition a genome into a set of overlapping segments')
 parser.add_argument('--segment-length', type=int, default=50000)
@@ -12,7 +12,9 @@ if len(extra) != 1:
     sys.stderr.write("Error: a genome file is expected\n")
 filename = extra[0]
 
-recs = [ (rec.name, len(rec.seq)) for rec in SeqIO.parse(open(filename), "fasta")]
+with open(filename) as handle:
+    recs = [(title.split(None, 1)[0], len(seq))
+            for title, seq in SimpleFastaParser(handle)]
 
 SEGMENT_LENGTH = args.segment_length
 OVERLAP_LENGTH = args.overlap_length

--- a/scripts/nanopolish_merge.py
+++ b/scripts/nanopolish_merge.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import sys
 import glob
-from Bio import SeqIO
+from Bio.SeqIO.FastaIO import SimpleFastaParser
 from Bio import pairwise2
 
 def merge_into_consensus(consensus, incoming, overlap_length):
@@ -69,14 +69,15 @@ segments_by_name = dict()
 
 # Load the polished segments into a dictionary keyed by the start coordinate
 for fn in sys.argv[1:]:
-    for rec in SeqIO.parse(open(fn), "fasta"):
-        (contig, segment_range) = rec.name.split(":")
+    with open(fn) as handle:
+        for title, seq in SimpleFastaParser(handle):
+            (contig, segment_range) = title.split(None, 1)[0].split(":")
 
-        if contig not in segments_by_name:
-            segments_by_name[contig] = dict()
+            if contig not in segments_by_name:
+                segments_by_name[contig] = dict()
 
-        segment_start, segment_end = segment_range.split("-")
-        segments_by_name[contig][int(segment_start)] = str(rec.seq)
+            segment_start, segment_end = segment_range.split("-")
+            segments_by_name[contig][int(segment_start)] = seq
 
 # Assemble while making sure every segment is present
 for contig_name in sorted(segments_by_name.keys()):


### PR DESCRIPTION
Low level FASTA parser generator function``SimpleFastaParser`` was introduced in Biopython 1.61 back in February 2013, so the dependencies shouldn't matter.

This avoids the overhead of building ``SeqRecord`` objects etc, so is several times faster.