### PR TITLE
Update quickstart_consensus.rst

### DIFF
--- a/docs/source/quickstart_consensus.rst
+++ b/docs/source/quickstart_consensus.rst
@@ -81,7 +81,7 @@ First step, is to index the draft genome assembly. We can do that with the follo
 
 Next, we align the original reads (``reads.fasta``) to the draft assembly (``draft.fa``) and sort alignments: ::
 
-    minimap2 -ax map-ont -t 8 draft.fa reads.fasta | samtools sort -o reads.sorted.bam -T reads.tmp
+    minimap2 -ax map-ont -t 8 draft.mmi reads.fasta | samtools sort -o reads.sorted.bam -T reads.tmp
     samtools index reads.sorted.bam
 
 **Checkpoint**: we can do a quick check to see if this step worked. The bam file should not be empty. ::


### PR DESCRIPTION
To benefit from indexing the reference with minimap the mapping should point to the index file rather than the fasta file  (https://github.com/lh3/minimap2)