### PR TITLE
SquiggleRead orientation fix

### DIFF
--- a/src/nanopolish_polya_estimator.cpp
+++ b/src/nanopolish_polya_estimator.cpp
@@ -378,8 +378,6 @@ public:
         viterbi_scores[0][HMM_START] = this->log_start_probs[HMM_START] + this->emit_log_proba(sr.samples[num_samples-1], HMM_START);
         viterbi_scores[0][HMM_LEADER] = this->log_start_probs[HMM_LEADER] + this->emit_log_proba(sr.samples[num_samples-1], HMM_LEADER);
         for (size_t i = 1; i < num_samples; ++i) {
-            // `t` moves from 3'->5' on the vector of samples, in opposite direction of `i`:
-            size_t t = (num_samples-1-i);
             // get individual incoming state scores:
             float s_to_s = viterbi_scores.at(i-1)[HMM_START] + this->log_state_transitions[HMM_START][HMM_START];
             float s_to_l = viterbi_scores.at(i-1)[HMM_START] + this->log_state_transitions[HMM_START][HMM_LEADER];
@@ -395,12 +393,12 @@ public:
             float t_to_t = viterbi_scores.at(i-1)[HMM_TRANSCRIPT] + this->log_state_transitions[HMM_TRANSCRIPT][HMM_TRANSCRIPT];
 
             // update the viterbi scores for each state at this timestep:
-            viterbi_scores.at(i)[HMM_START] = s_to_s + this->emit_log_proba(sr.samples[t], HMM_START);
-            viterbi_scores.at(i)[HMM_LEADER] = std::max(l_to_l, s_to_l) + this->emit_log_proba(sr.samples[t], HMM_LEADER);
-            viterbi_scores.at(i)[HMM_ADAPTER] = std::max(a_to_a, l_to_a) + this->emit_log_proba(sr.samples[t], HMM_ADAPTER);
-            viterbi_scores.at(i)[HMM_POLYA] = std::max(p_to_p, std::max(a_to_p, c_to_p)) + this->emit_log_proba(sr.samples[t], HMM_POLYA);
-            viterbi_scores.at(i)[HMM_CLIFF] = std::max(c_to_c, p_to_c) + this->emit_log_proba(sr.samples[t], HMM_CLIFF);
-            viterbi_scores.at(i)[HMM_TRANSCRIPT] = std::max(p_to_t, t_to_t) + this->emit_log_proba(sr.samples[t], HMM_TRANSCRIPT);
+            viterbi_scores.at(i)[HMM_START] = s_to_s + this->emit_log_proba(sr.samples[i], HMM_START);
+            viterbi_scores.at(i)[HMM_LEADER] = std::max(l_to_l, s_to_l) + this->emit_log_proba(sr.samples[i], HMM_LEADER);
+            viterbi_scores.at(i)[HMM_ADAPTER] = std::max(a_to_a, l_to_a) + this->emit_log_proba(sr.samples[i], HMM_ADAPTER);
+            viterbi_scores.at(i)[HMM_POLYA] = std::max(p_to_p, std::max(a_to_p, c_to_p)) + this->emit_log_proba(sr.samples[i], HMM_POLYA);
+            viterbi_scores.at(i)[HMM_CLIFF] = std::max(c_to_c, p_to_c) + this->emit_log_proba(sr.samples[i], HMM_CLIFF);
+            viterbi_scores.at(i)[HMM_TRANSCRIPT] = std::max(p_to_t, t_to_t) + this->emit_log_proba(sr.samples[i], HMM_TRANSCRIPT);
 
             // backpointers:
             // START: S can only come from S
@@ -754,9 +752,8 @@ void estimate_polya_for_single_read(const ReadDB& read_db,
     uint32_t prefix_clip = bam_cigar_oplen(prefix_cigar);
     uint32_t suffix_clip = bam_cigar_oplen(suffix_cigar);
 
-    // ---- construct SquiggleRead and reverse samples to 3'->5':
+    //----- construct SquiggleRead:
     SquiggleRead sr(read_name, read_db, SRF_LOAD_RAW_SAMPLES);
-    std::reverse(sr.samples.begin(), sr.samples.end());
 
     //----- print clipping data if `verbose > 2` set:
     if (opt::verbose > 2) {


### PR DESCRIPTION
A previous fix for the `--samples` flag broke the orientation assumption for the viterbi algorithm implementation in `SegmentationHMM` of the poly-A estimator. These commits fix the viterbi algorithm implementation.