### PR TITLE
Improve yield by deprecating pre-segmentation QC test

### DIFF
--- a/src/nanopolish_polya_estimator.cpp
+++ b/src/nanopolish_polya_estimator.cpp
@@ -669,10 +669,6 @@ bool pre_segmentation_qc(uint32_t suffix_clip, uint32_t prefix_clip, double tran
     if (suffix_clip > 200) {
         return true;
     }
-    // skip this read if most of transcript wasnt aligned:
-    if ((double)(prefix_clip + suffix_clip) / transcript_length > 0.2) {
-        return true;
-    }
     // skip if no events:
     if (sr.events[0].empty()) {
         return true;


### PR DESCRIPTION
The QC test that ensures soft-clipping is never more than 20% of the length of the total transcript length is a hold-over from an older version of the code that doesn't use the median event duration as a robust estimator of global read-rate for a given read. Removing it gives a ~50% improvement in yield (number of reads that have estimates) while keeping estimates almost the same. (For longer-length datasets, 80xA-100xA the estimates are ever so slightly better in distribution.)