### PR TITLE
Add the test case of latest version gcc 8 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,46 @@
 # travis.yml for github.com/jts/nanopolish
 
-language: cpp
+dist: trusty
+sudo: false
+language: generic
+cache: apt
+git:
+  depth: 1
+
+matrix:
+  include:
+    # Set env for both nanoplish and the dependency hdf5.
+    - env:
+      - CC=gcc-4.8
+      - CXX=g++-4.8
+      - AR=gcc-ar-4.8
+      - NM=gcc-nm-4.8
+      - RANLIB=gcc-ranlib-4.8
+    - env:
+      - CC=gcc-8
+      - CXX=g++-8
+      - AR=gcc-ar-8
+      - NM=gcc-nm-8
+      - RANLIB=gcc-ranlib-8
 
 # Install and export newer gcc
 before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update -qq
-    - sudo apt-get install -qq g++-4.8
+    - |
+      if [[ "${CC}" =~ ^gcc- ]]; then
+        echo "Installing ${CC}."
+        sudo apt-get install -qq "${CC}"
+      fi
+    - |
+      if [[ "${CXX}" =~ ^g\+\+- ]]; then
+        echo "Installing ${CXX}."
+        sudo apt-get install -qq "${CXX}"
+      fi
 
-script: make CXX=g++-4.8 nanopolish && make CXX=g++-4.8 test
+script:
+  # Suppress all compiler warnings for hdf5 Makefile
+  # to display the log without downloading the raw log on Travis log page.
+  # Travis finishs with error when exceeding the limit of 4 MB of log length.
+  - export H5_CFLAGS="-w"
+  - make nanopolish && make test

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ lib/libhdf5.a:
 # Download and install eigen if not already downloaded
 eigen/INSTALL:
 	if [ ! -e 3.2.5.tar.bz2 ]; then wget http://bitbucket.org/eigen/eigen/get/3.2.5.tar.bz2; fi
-	tar -xjvf 3.2.5.tar.bz2 || exit 255
+	tar -xjf 3.2.5.tar.bz2 || exit 255
 	mv eigen-eigen-bdd17ee3b1b3 eigen || exit 255
 
 #


### PR DESCRIPTION
This fixes https://github.com/jts/nanopolish/issues/458 .

I needed to suppress verbose log, because maybe gcc-8 outputs more log than gcc-4.8. I faced Travis error because of exceeding of the limitation of the Travis log output length.

As a good result, after this pull-request, we can check entire Travis log from the Travis log page, without downloading the raw log file.
This is beneficial for development, isn't it?
