### PR TITLE
Refactor Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SUBDIRS := src src/hmm src/thirdparty src/thirdparty/scrappie src/common src/ali
 #
 
 #Basic flags every build needs
-LIBS=-lz
+LIBS = -lz
 CXXFLAGS ?= -g -O3
 CXXFLAGS += -std=c++11 -fopenmp -fsigned-char
 CFLAGS ?= -O3 -std=c99
@@ -16,9 +16,9 @@ CXX ?= g++
 CC ?= gcc
 
 # Change the value of HDF5, EIGEN, or HTS below to any value to disable compilation of bundled code
-HDF5?=install
-EIGEN?=install
-HTS?=install
+HDF5 ?= install
+EIGEN ?= install
+HTS ?= install
 
 # Check operating system, OSX doesn't have -lrt
 UNAME_S := $(shell uname -s)
@@ -28,51 +28,52 @@ endif
 
 # Default to automatically installing hdf5
 ifeq ($(HDF5), install)
-    H5_LIB=./lib/libhdf5.a
-    H5_INCLUDE=-I./include
+    H5_LIB = ./lib/libhdf5.a
+    H5_INCLUDE = -I./include
     LIBS += -ldl
 else
     # Use system-wide hdf5
-    H5_LIB=
-    H5_INCLUDE=
+    H5_LIB =
+    H5_INCLUDE =
     LIBS += -lhdf5
 endif
 
 # Default to automatically installing EIGEN
 ifeq ($(EIGEN), install)
-    EIGEN_CHECK=eigen/INSTALL
+    EIGEN_CHECK = eigen/INSTALL
 else
     # Use system-wide eigen
-    EIGEN_CHECK=
+    EIGEN_CHECK =
 endif
 
 # Default to build and link the libhts submodule
 ifeq ($(HTS), install)
-    HTS_LIB=./htslib/libhts.a
-    HTS_INCLUDE=-I./htslib
+    HTS_LIB = ./htslib/libhts.a
+    HTS_INCLUDE = -I./htslib
 else
     # Use system-wide htslib
-    HTS_LIB=
-    HTS_INCLUDE=
+    HTS_LIB =
+    HTS_INCLUDE =
     LIBS += -lhts
 endif
 
 # Include the header-only fast5 library
-FAST5_INCLUDE=-I./fast5/include
+FAST5_INCLUDE = -I./fast5/include
 
 # Include the header-only eigen library
-EIGEN_INCLUDE=-I./eigen/
+EIGEN_INCLUDE = -I./eigen/
 
 # Include the src subdirectories
-NP_INCLUDE=$(addprefix -I./, $(SUBDIRS))
+NP_INCLUDE = $(addprefix -I./, $(SUBDIRS))
 
 # Add include flags
 CPPFLAGS += $(H5_INCLUDE) $(HTS_INCLUDE) $(FAST5_INCLUDE) $(NP_INCLUDE) $(EIGEN_INCLUDE)
 
 # Main programs to build
-PROGRAM=nanopolish
-TEST_PROGRAM=nanopolish_test
+PROGRAM = nanopolish
+TEST_PROGRAM = nanopolish_test
 
+.PHONY: all
 all: $(PROGRAM) $(TEST_PROGRAM)
 
 #
@@ -85,14 +86,19 @@ htslib/libhts.a:
 # If this library is a dependency the user wants HDF5 to be downloaded and built.
 #
 lib/libhdf5.a:
-	if [ ! -e hdf5-1.8.14.tar.gz ]; then wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.14/src/hdf5-1.8.14.tar.gz; fi
+	if [ ! -e hdf5-1.8.14.tar.gz ]; then \
+		wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.14/src/hdf5-1.8.14.tar.gz; \
+	fi
 	tar -xzf hdf5-1.8.14.tar.gz || exit 255
-	cd hdf5-1.8.14 && ./configure --enable-threadsafe --prefix=`pwd`/.. && make && make install
-
+	cd hdf5-1.8.14 && \
+		./configure --enable-threadsafe --prefix=`pwd`/.. && \
+		make && make install
 
 # Download and install eigen if not already downloaded
 eigen/INSTALL:
-	if [ ! -e 3.2.5.tar.bz2 ]; then wget http://bitbucket.org/eigen/eigen/get/3.2.5.tar.bz2; fi
+	if [ ! -e 3.2.5.tar.bz2 ]; then \
+		wget http://bitbucket.org/eigen/eigen/get/3.2.5.tar.bz2; \
+	fi
 	tar -xjf 3.2.5.tar.bz2 || exit 255
 	mv eigen-eigen-bdd17ee3b1b3 eigen || exit 255
 
@@ -103,14 +109,14 @@ eigen/INSTALL:
 # Find the source files by searching subdirectories
 CPP_SRC := $(foreach dir, $(SUBDIRS), $(wildcard $(dir)/*.cpp))
 C_SRC := $(foreach dir, $(SUBDIRS), $(wildcard $(dir)/*.c))
-EXE_SRC=src/main/nanopolish.cpp src/test/nanopolish_test.cpp
+EXE_SRC = src/main/nanopolish.cpp src/test/nanopolish_test.cpp
 
 # Automatically generated object names
-CPP_OBJ=$(CPP_SRC:.cpp=.o)
-C_OBJ=$(C_SRC:.c=.o)
+CPP_OBJ = $(CPP_SRC:.cpp=.o)
+C_OBJ = $(C_SRC:.c=.o)
 
 # Generate dependencies
-PHONY=depend
+.PHONY: depend
 depend: .depend
 
 .depend: $(CPP_SRC) $(C_SRC) $(EXE_SRC) $(H5_LIB) $(EIGEN_CHECK)
@@ -134,8 +140,11 @@ $(PROGRAM): src/main/nanopolish.o $(CPP_OBJ) $(C_OBJ) $(HTS_LIB) $(H5_LIB) $(EIG
 $(TEST_PROGRAM): src/test/nanopolish_test.o $(CPP_OBJ) $(C_OBJ) $(HTS_LIB) $(H5_LIB)
 	$(CXX) -o $@ $(CXXFLAGS) $(CPPFLAGS) -fPIC $< $(CPP_OBJ) $(C_OBJ) $(HTS_LIB) $(H5_LIB) $(LIBS) $(LDFLAGS)
 
+.PHONY: test
 test: $(TEST_PROGRAM)
 	./$(TEST_PROGRAM)
 
+.PHONY: clean
 clean:
-	rm -f $(PROGRAM) $(TEST_PROGRAM) $(CPP_OBJ) $(C_OBJ) src/main/nanopolish.o src/test/nanopolish_test.o
+	rm -f $(PROGRAM) $(TEST_PROGRAM) $(CPP_OBJ) $(C_OBJ) \
+		src/main/nanopolish.o src/test/nanopolish_test.o


### PR DESCRIPTION
I did refactoring for `Makefile`.

* Right now there is a mixture of "FOO = bar" (with space) and "FOO=bar" (without space).
  I aligned with " = " (with space). 
  Seeing ruby Makefile, it is aligned with the way.
  https://github.com/ruby/ruby/blob/trunk/Makefile.in
* Add line break and escape "\" to shell code.
  It looks easier to understand shell lines in `Makefile`.
* Add .PHONY target safely for non-file target.
