### PR TITLE
Update not to run ".depend" task when running "make clean".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ script:
     # to display the log without downloading the raw log on Travis log page.
     # Travis finishs with error when exceeding the limit of 4 MB of log length.
     - export H5_CFLAGS="-w"
-    - make nanopolish && make test
+    - make && make test

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ PROGRAM = nanopolish
 TEST_PROGRAM = nanopolish_test
 
 .PHONY: all
-all: $(PROGRAM) $(TEST_PROGRAM)
+all: depend $(PROGRAM)
 
 #
 # Build libhts
@@ -122,8 +122,6 @@ depend: .depend
 .depend: $(CPP_SRC) $(C_SRC) $(EXE_SRC) $(H5_LIB) $(EIGEN_CHECK)
 	rm -f ./.depend
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MM $(CPP_SRC) $(C_SRC) > ./.depend;
-
-include .depend
 
 # Compile objects
 .cpp.o:


### PR DESCRIPTION
In this pull-request, maybe we might need discussion.

The situation is when run "make clean", ".depend" task is run.
As we know, the task is always run.

I want to change this behavior.
Because when people want to remove files, the dependency installation starts. That's not intuitive.

I like to run the ".depend" when only "make nanopolish" is run.
And considering how to inject "depend" task, I think "make & make test" can be used instead of "make nanopolish & make test" after this pull-request.

How do you think?