### PR TITLE
Update to build with specified version's dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ HDF5 ?= install
 EIGEN ?= install
 HTS ?= install
 
+HDF5_VERSION ?= 1.8.14
+HDF5_CONFIG_ARGS ?= --enable-threadsafe
+EIGEN_VERSION ?= 3.2.5
+
 # Check operating system, OSX doesn't have -lrt
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
@@ -86,21 +90,22 @@ htslib/libhts.a:
 # If this library is a dependency the user wants HDF5 to be downloaded and built.
 #
 lib/libhdf5.a:
-	if [ ! -e hdf5-1.8.14.tar.gz ]; then \
-		wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.14/src/hdf5-1.8.14.tar.gz; \
+	if [ ! -e hdf5-$(HDF5_VERSION).tar.gz ]; then \
+		version_major_minior=`echo "$(HDF5_VERSION)" | sed -E 's/\.[0-9]+$$//'`; \
+		wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$${version_major_minior}/hdf5-$(HDF5_VERSION)/src/hdf5-$(HDF5_VERSION).tar.gz; \
 	fi
-	tar -xzf hdf5-1.8.14.tar.gz || exit 255
-	cd hdf5-1.8.14 && \
-		./configure --enable-threadsafe --prefix=`pwd`/.. && \
+	tar -xzf hdf5-$(HDF5_VERSION).tar.gz || exit 255
+	cd hdf5-$(HDF5_VERSION) && \
+		./configure $(HDF5_CONFIG_ARGS) --prefix=`pwd`/.. && \
 		make && make install
 
 # Download and install eigen if not already downloaded
 eigen/INSTALL:
-	if [ ! -e 3.2.5.tar.bz2 ]; then \
-		wget http://bitbucket.org/eigen/eigen/get/3.2.5.tar.bz2; \
+	if [ ! -e $(EIGEN_VERSION).tar.bz2 ]; then \
+		wget http://bitbucket.org/eigen/eigen/get/$(EIGEN_VERSION).tar.bz2; \
 	fi
-	tar -xjf 3.2.5.tar.bz2 || exit 255
-	mv eigen-eigen-bdd17ee3b1b3 eigen || exit 255
+	tar -xjf $(EIGEN_VERSION).tar.bz2 || exit 255
+	mv eigen-eigen-* eigen || exit 255
 
 #
 # Source files


### PR DESCRIPTION
This feature is to build with dependencies (`hdf5` and `eigen`)' version specified by environment variable. 

The benefits are
* We can upgrade the default version easily by changing 1 line in `Makefile`.
* Maybe we want to pin the dependency version when upgrading maintenance version, as we manage the version `v{major}.{minor}.{maintenance}`. In other words, we want to test the latest version of the dependency anytime. We might want to change the default dependency version in `Makefile` only when we upgrade major or minor version.
* Perhaps we want to test `nanopolish` with specific old version dependencies. In this mechanism, it is easier.

hdf5 latest version is 1.10.3.
https://portal.hdfgroup.org/display/support/Downloads

eigen latest version is 3.3.5.
http://bitbucket.org/eigen/eigen

The latest version hdf5 1.10.3 changed the specification of the `configure` script.
That's why I added `--disable-hl` for the case from `.travis.yml`.
We might need consider the better configure arguments for the case.

When I ran hdf5 `configure` script without `--disable-hl` argument, I got below error.

```
$ ./configure --enable-threadsafe
...
checking for thread safe support... configure: error: The thread-safe library is incompatible with the high-level library. --disable-hl can be used to prevent building the high-level library (recommended). Alternatively, --enable-unsupported will allow building the high-level library, though this configuration is not supported by The HDF Group.
make: *** [lib/libhdf5.a] Error 1
...
```

I checked the help by `./configure --help`.

```
$ ./configure --help
  --enable-threadsafe     Enable thread-safe capability. Not compatible with
                          the high-level library, Fortran, or C++ wrappers.
                          [default=no]
```

I added "(display) name" tag experimentally that's added recently to Travis CI.
https://github.com/travis-ci/travis-ci/issues/5898