### PR TITLE
Add ARM case on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ git:
           - |
             docker run --rm -t \
                 -e HDF5="${HDF5:-install}" \
-                -e HDF5_VERSION="${HDF5_VERSION}" \
-                -e HDF5_CONFIG_ARGS="${HDF5_CONFIG_ARGS}" \
                 -e H5_CFLAGS="${H5_CFLAGS}" \
                 -e H5_INCLUDE="${H5_INCLUDE}" \
                 -e LDFLAGS="${LDFLAGS}" \
@@ -50,8 +48,6 @@ matrix:
           sudo: required
           env:
               - ARCH=arm64
-              - HDF5_VERSION=1.10.4
-              - HDF5_CONFIG_ARGS=""
           <<: *arch
           <<: *cron-only
         - name: aarch64-system-hdf5
@@ -67,8 +63,6 @@ matrix:
           sudo: required
           env:
               - ARCH=armhf
-              - HDF5_VERSION=1.10.4
-              - HDF5_CONFIG_ARGS=""
           <<: *arch
           <<: *cron-only
         - name: armv7l-system-hdf5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,89 @@
 # travis.yml for github.com/jts/nanopolish
 
 dist: trusty
+services: docker
 sudo: false
 language: generic
 cache: apt
 git:
     depth: 1
 
+.nanopolish.ci.matrix-definitions:
+    - &cron-only
+      if: type = cron OR env(CI_CRON) = true
+    - &arch
+      before_install:
+          - |
+            sed -i "/^FROM / s/arm64/${ARCH}/" Dockerfile-arm
+          - |
+            docker run --rm --privileged \
+                multiarch/qemu-user-static:register --reset && \
+                docker build --rm -t nanopolish -f Dockerfile-arm .
+      script:
+          - |
+            docker run --rm -t \
+                -e HDF5="${HDF5:-install}" \
+                -e HDF5_VERSION="${HDF5_VERSION}" \
+                -e HDF5_CONFIG_ARGS="${HDF5_CONFIG_ARGS}" \
+                -e H5_CFLAGS="${H5_CFLAGS}" \
+                -e H5_INCLUDE="${H5_INCLUDE}" \
+                -e LDFLAGS="${LDFLAGS}" \
+                nanopolish
+
 matrix:
     include:
-    # Set env for both nanoplish and the dependency hdf5.
-    - env:
-        - CC=gcc-4.8
-        - CXX=g++-4.8
-        - AR=gcc-ar-4.8
-        - NM=gcc-nm-4.8
-        - RANLIB=gcc-ranlib-4.8
-    - env:
-        - CC=gcc-8
-        - CXX=g++-8
-        - AR=gcc-ar-8
-        - NM=gcc-nm-8
-        - RANLIB=gcc-ranlib-8
+        # Set env for both nanoplish and the dependency hdf5.
+        - env:
+              - CC=gcc-4.8
+              - CXX=g++-4.8
+              - AR=gcc-ar-4.8
+              - NM=gcc-nm-4.8
+              - RANLIB=gcc-ranlib-4.8
+        - env:
+              - CC=gcc-8
+              - CXX=g++-8
+              - AR=gcc-ar-8
+              - NM=gcc-nm-8
+              - RANLIB=gcc-ranlib-8
+        # aarch64 - ARM 64-bit
+        - name: aarch64
+          sudo: required
+          env:
+              - ARCH=arm64
+              - HDF5_VERSION=1.10.4
+              - HDF5_CONFIG_ARGS=""
+          <<: *arch
+          <<: *cron-only
+        - name: aarch64-system-hdf5
+          sudo: required
+          env:
+              - ARCH=arm64
+              - HDF5="system"
+              - H5_INCLUDE="-I/usr/include/hdf5/serial"
+              - LDFLAGS="-L/usr/lib/aarch64-linux-gnu/hdf5/serial"
+          <<: *arch
+        # armv7l - ARM 32-bit
+        - name: armv7l
+          sudo: required
+          env:
+              - ARCH=armhf
+              - HDF5_VERSION=1.10.4
+              - HDF5_CONFIG_ARGS=""
+          <<: *arch
+          <<: *cron-only
+        - name: armv7l-system-hdf5
+          sudo: required
+          env:
+              - ARCH=armhf
+              - HDF5="system"
+              - H5_INCLUDE="-I/usr/include/hdf5/serial"
+              - LDFLAGS="-L/usr/lib/arm-linux-gnueabihf/hdf5/serial"
+          <<: *arch
+    allow_failures:
+        # The jobs installing hdf5 from source in docker finishes with error
+        # because of the job exceeded the maximum time limit (50 minutes).
+        - name: aarch64
+        - name: armv7l
 
 # Install and export newer gcc
 before_install:
@@ -38,9 +100,11 @@ before_install:
           sudo apt-get install -qq "${CXX}"
       fi
 
-script:
+before_script:
     # Suppress all compiler warnings for hdf5 Makefile
     # to display the log without downloading the raw log on Travis log page.
     # Travis finishs with error when exceeding the limit of 4 MB of log length.
     - export H5_CFLAGS="-w"
+
+script:
     - make && make test

--- a/Dockerfile-arm
+++ b/Dockerfile-arm
@@ -1,0 +1,18 @@
+FROM multiarch/ubuntu-debootstrap:arm64-bionic
+RUN uname -a
+RUN apt-get update -qq && \
+  apt-get install -yq --no-install-suggests --no-install-recommends \
+  bzip2 \
+  ca-certificates \
+  gcc \
+  g++ \
+  make \
+  software-properties-common
+RUN add-apt-repository -y universe && \
+  apt-get update -qq && \
+  apt-get install -yq libhdf5-dev
+RUN find /usr/include -name "hdf5.h" || true
+RUN find /usr/lib -name "libhdf5.a" || true
+WORKDIR /nanopolish
+COPY . .
+CMD exec bash -c "make && make test"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LIBS = -lz
 CXXFLAGS ?= -g -O3
 CXXFLAGS += -std=c++11 -fopenmp -fsigned-char -D_FILE_OFFSET_BITS=64 #D_FILE_OFFSET_BITS=64 makes nanopolish work in 32 bit systems
 CFLAGS ?= -O3 -std=c99 -fsigned-char -D_FILE_OFFSET_BITS=64 
+LDFLAGS ?=
 CXX ?= g++
 CC ?= gcc
 
@@ -38,7 +39,7 @@ ifeq ($(HDF5), install)
 else
     # Use system-wide hdf5
     H5_LIB =
-    H5_INCLUDE =
+    H5_INCLUDE ?=
     LIBS += -lhdf5
 endif
 
@@ -97,7 +98,7 @@ lib/libhdf5.a:
 
 	tar -xzf hdf5-$(HDF5_VERSION).tar.gz || exit 255
 	cd hdf5-$(HDF5_VERSION) && \
-        ./configure --enable-threadsafe --libdir=`pwd`/../lib --includedir=`pwd`/../include --prefix=`pwd`/.. && \
+		./configure $(HDF5_CONFIG_ARGS) --libdir=`pwd`/../lib --includedir=`pwd`/../include --prefix=`pwd`/.. && \
 		make && make install
 
 # Download and install eigen if not already downloaded

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ HDF5 ?= install
 EIGEN ?= install
 HTS ?= install
 
-HDF5_VERSION ?= 1.8.14
-HDF5_CONFIG_ARGS ?= --enable-threadsafe
+HDF5_VERSION ?= 1.10.4
 EIGEN_VERSION ?= 3.2.5
 
 # Check operating system, OSX doesn't have -lrt
@@ -98,7 +97,7 @@ lib/libhdf5.a:
 
 	tar -xzf hdf5-$(HDF5_VERSION).tar.gz || exit 255
 	cd hdf5-$(HDF5_VERSION) && \
-		./configure $(HDF5_CONFIG_ARGS) --libdir=`pwd`/../lib --includedir=`pwd`/../include --prefix=`pwd`/.. && \
+		./configure --enable-threadsafe --disable-hl --libdir=`pwd`/../lib --includedir=`pwd`/../include --prefix=`pwd`/.. && \
 		make && make install
 
 # Download and install eigen if not already downloaded


### PR DESCRIPTION
This PR is to add both `aarch64` (ARM 64-bit) and `armv7hl` (ARM 32-bit).

Right now working in progress. But I think it's worth to share in advance.
Here is the result.
https://travis-ci.org/junaruga/nanopolish/builds/444505171

There are some notes

* Using QEMU and Docker container technology to test ARM environment on Travis. [1][2]
* The running time of the added ARM test cases are longer.
  In this issue, I would recommend to use conditional job [3] like this. This is only run for Travis cron mode or environment variable `CI_CRON` is set as `1` from Travis setting page.

```
+    - name: aarch64
+      sudo: required
+      env:
+        - ARCH=arm64
+      if: type = cron OR env(CI_CRON) = 1
```

* I am trying to skip to build hdfs5 from the source code. Instead of that use system-wide hdfs5 devel library to save the running time. The I faced bellow error. Could you give some an advice for that?

```
src/thirdparty/scrappie/util.h:4:14: fatal error: immintrin.h: No such file or directory
 #    include <immintrin.h>
              ^~~~~~~~~~~~~
```

* [1] The technology: https://github.com/multiarch/qemu-user-static
* [2] The container: https://hub.docker.com/r/multiarch/ubuntu-debootstrap/tags/
* [3] Travis conditions: https://docs.travis-ci.com/user/conditions-v1
