### PR TITLE
Changed keys to a tuple

### DIFF
--- a/scripts/calculate_methylation_frequency.py
+++ b/scripts/calculate_methylation_frequency.py
@@ -6,17 +6,9 @@ import csv
 import argparse
 from collections import namedtuple
 
-def make_key(c, s, e):
-    return c + ":" + str(s) + ":" + str(e)
-
-def split_key(k):
-    f = k.split(":")
-    return (f[0], int(f[1]), int(f[2]))
-
 class SiteStats:
     def __init__(self, g_size, g_seq):
         self.num_reads = 0
-        self.posterior_methylated = 0
         self.called_sites = 0
         self.called_sites_methylated = 0
         self.group_size = g_size
@@ -60,7 +52,7 @@ for record in csv_reader:
     
     # if this is a multi-cpg group and split_groups is set, break up these sites
     if args.split_groups and num_sites > 1:
-        c = record['chromosome'] 
+        c = str(record['chromosome']) 
         s = int(record['start'])
         e = int(record['end'])
 
@@ -69,20 +61,20 @@ for record in csv_reader:
         cg_pos = sequence.find("CG")
         first_cg_pos = cg_pos
         while cg_pos != -1:
-            key = make_key(c, s + cg_pos - first_cg_pos, s + cg_pos - first_cg_pos)
+            key = (c, s + cg_pos - first_cg_pos, s + cg_pos - first_cg_pos)
             update_call_stats(key, 1, is_methylated, "split-group")
             cg_pos = sequence.find("CG", cg_pos + 1)
     else:
-        key = make_key(record['chromosome'], record['start'], record['end'])
+        key = (str(record['chromosome']), int(record['start']), int(record['end']))
         update_call_stats(key, num_sites, is_methylated, sequence)
 
 # header
 print("\t".join(["chromosome", "start", "end", "num_motifs_in_group", "called_sites", "called_sites_methylated", "methylated_frequency", "group_sequence"]))
 
-sorted_keys = sorted(sites.keys(), key = lambda x: split_key(x))
+sorted_keys = sorted(sites.keys(), key = lambda x: x)
 
 for key in sorted_keys:
     if sites[key].called_sites > 0:
-        (c, s, e) = key.split(":")
+        (c, s, e) = key
         f = float(sites[key].called_sites_methylated) / sites[key].called_sites
         print("%s\t%s\t%s\t%d\t%d\t%d\t%.3f\t%s" % (c, s, e, sites[key].group_size, sites[key].called_sites, sites[key].called_sites_methylated, f, sites[key].sequence))


### PR DESCRIPTION
Changed the type of key used to a tuple.  The previous method would give errors if the chromosome name had a colon in it.