### PR TITLE
Rename PT_R[79] enums to PORETYPE_R[79]

### DIFF
--- a/src/hmm/nanopolish_profile_hmm.cpp
+++ b/src/hmm/nanopolish_profile_hmm.cpp
@@ -22,7 +22,7 @@ float profile_hmm_score(const HMMInputSequence& sequence, const std::vector<HMMI
 
 float profile_hmm_score(const HMMInputSequence& sequence, const HMMInputData& data, const uint32_t flags)
 {
-    if(data.read->pore_type == PT_R9) {
+    if(data.read->pore_type == PORETYPE_R9) {
         return profile_hmm_score_r9(sequence, data, flags);
     } else {
         return profile_hmm_score_r7(sequence, data, flags);
@@ -57,7 +57,7 @@ float profile_hmm_score_set(const std::vector<HMMInputSequence>& sequences, cons
 
 std::vector<HMMAlignmentState> profile_hmm_align(const HMMInputSequence& sequence, const HMMInputData& data, const uint32_t flags)
 {
-    if(data.read->pore_type == PT_R9) {
+    if(data.read->pore_type == PORETYPE_R9) {
         return profile_hmm_align_r9(sequence, data, flags);
     } else {
         return profile_hmm_align_r7(sequence, data, flags);

--- a/src/nanopolish_call_variants.cpp
+++ b/src/nanopolish_call_variants.cpp
@@ -673,7 +673,7 @@ Haplotype fix_homopolymers(const Haplotype& input_haplotype,
 
                 double num_kmers = variant_offset_end - variant_offset_start;
                 double log_gamma = sum_duration > MIN_DURATION ?  DurationModel::log_gamma_sum(sum_duration, params, num_kmers) : 0.0f;
-                if(read->pore_type == PT_R9) {
+                if(read->pore_type == PORETYPE_R9) {
                     duration_likelihoods[var_sequence_length] += log_gamma;
                 }
                 if(opt::verbose > 3) {

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -106,7 +106,7 @@ SquiggleRead::SquiggleRead(const std::string& sequence, const Fast5Data& data, c
 void SquiggleRead::init(const std::string& read_sequence, const Fast5Data& data, const uint32_t flags)
 {
     this->nucleotide_type = SRNT_DNA;
-    this->pore_type = PT_UNKNOWN;
+    this->pore_type = PORETYPE_UNKNOWN;
     this->f_p = nullptr;
 
     this->events_per_base[0] = events_per_base[1] = 0.0f;
@@ -219,7 +219,7 @@ void SquiggleRead::load_from_events(const uint32_t flags)
         // in this case, we have to set this strand to be invalid
         if(!event_maps_1d[si].empty()) {
             // run version-specific load
-            if(pore_type == PT_R7) {
+            if(pore_type == PORETYPE_R7) {
                 _load_R7(si);
             } else {
                 _load_R9(si, read_sequences_1d[si], event_maps_1d[si], p_model_states, flags);
@@ -231,10 +231,10 @@ void SquiggleRead::load_from_events(const uint32_t flags)
 
     // Build the map from k-mers of the read sequence to events
     if(read_type == SRT_2D) {
-        if(pore_type == PT_R9) {
+        if(pore_type == PORETYPE_R9) {
             build_event_map_2d_r9();
         } else {
-            assert(pore_type == PT_R7);
+            assert(pore_type == PORETYPE_R7);
             build_event_map_2d_r7();
         }
     } else {
@@ -298,7 +298,7 @@ void SquiggleRead::load_from_raw(const Fast5Data& fast5_data, const uint32_t fla
     }
 
     this->read_type = SRT_TEMPLATE;
-    this->pore_type = PT_R9;
+    this->pore_type = PORETYPE_R9;
 
     // Set the base model for this read to either the nucleotide or U->T RNA model
     this->base_model[strand_idx] = PoreModelSet::get_model(kit, alphabet, strand_str, k);
@@ -1122,11 +1122,11 @@ void SquiggleRead::detect_pore_type()
     assert(f_p and f_p->is_open());
     if (f_p->have_basecall_model(0))
     {
-        pore_type = PT_R7;
+        pore_type = PORETYPE_R7;
     }
     else
     {
-        pore_type = PT_R9;
+        pore_type = PORETYPE_R9;
     }
 }
 

--- a/src/nanopolish_squiggle_read.h
+++ b/src/nanopolish_squiggle_read.h
@@ -21,9 +21,9 @@
 
 enum PoreType
 {
-    PT_UNKNOWN = 0,
-    PT_R7,
-    PT_R9,
+    PORETYPE_UNKNOWN = 0,
+    PORETYPE_R7,
+    PORETYPE_R9,
 };
 
 // the type of the read


### PR DESCRIPTION
This is to avoid a name clash of the `PT_R7` and `PT_R9` enums with values defined by some architecture-specific header on PowerPC platforms.

Closes #883.