### PR TITLE
slow5 as an input file option

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "minimap2"]
 	path = minimap2
 	url = https://github.com/lh3/minimap2
+[submodule "slow5lib"]
+	path = slow5lib
+	url = https://github.com/hasindu2008/slow5lib

--- a/src/nanopolish_index.cpp
+++ b/src/nanopolish_index.cpp
@@ -40,7 +40,6 @@ static const char *INDEX_USAGE_MESSAGE =
 "      --help                           display this help and exit\n"
 "      --version                        display version\n"
 "  -v, --verbose                        display verbose output\n"
-" -t INT                                number of threads used for bgzf compression (makes indexing faster)\n"
 "      --slow5 FILE                     slow5 file\n"
 "  -d, --directory                      path to the directory containing the raw ONT signal files. This option can be given multiple times.\n"
 "  -s, --sequencing-summary             the sequencing summary file from albacore, providing this option will make indexing much faster\n"
@@ -54,7 +53,6 @@ namespace opt
     static std::string reads_file;
     static std::vector<std::string> sequencing_summary_files;
     static std::string sequencing_summary_fofn;
-    static int threads = 1;
     static char *slow5file = NULL;
 }
 static std::ostream* os_p;
@@ -228,8 +226,7 @@ static const struct option longopts[] = {
     { "directory",                 required_argument, NULL, 'd' }, //4
     { "sequencing-summary-file",   required_argument, NULL, 's' }, //5
     { "summary-fofn",              required_argument, NULL, 'f' }, //6
-    { "threads",                   required_argument, NULL, 't'}, //7
-    { "slow5",                     required_argument, NULL, 0}, //8
+    { "slow5",                     required_argument, NULL, 0}, //7
     { NULL, 0, NULL, 0 }
 };
 
@@ -254,15 +251,8 @@ void parse_index_options(int argc, char** argv)
             case 's': opt::sequencing_summary_files.push_back(arg.str()); break;
             case 'd': opt::raw_file_directories.push_back(arg.str()); break;
             case 'f': arg >> opt::sequencing_summary_fofn; break;
-            case 't':
-                arg >> opt::threads;
-                if (opt::threads < 1) {
-                    fprintf(stderr, "Number of threads should be larger than 0. You entered %d\n", opt::threads);
-                    exit(EXIT_FAILURE);
-                }
-                break;
             case  0 :
-                if (longindex == 8) {
+                if (longindex == 7) {
                     opt::slow5file = optarg;
                 }
                 break;
@@ -377,7 +367,7 @@ int index_main(int argc, char** argv)
 
         // import read names, and possibly fast5 paths, from the fasta/fastq file
         ReadDB read_db;
-        read_db.build(opt::reads_file, opt::threads);
+        read_db.build(opt::reads_file);
         bool all_reads_have_paths = read_db.check_signal_paths();
 
         // if the input fastq did not contain a complete set of paths
@@ -417,7 +407,7 @@ int index_main(int argc, char** argv)
         slow5_close(sp);
 
         ReadDB read_db;
-        read_db.build(opt::reads_file, opt::threads);
+        read_db.build(opt::reads_file);
         read_db.clean();
 
     }

--- a/src/nanopolish_index.cpp
+++ b/src/nanopolish_index.cpp
@@ -210,7 +210,7 @@ void parse_sequencing_summary(const std::string& filename, std::multimap<std::st
     }
 }
 
-static const char* shortopts = "vd:f:s:t:";
+static const char* shortopts = "vd:f:s:";
 
 enum {
     OPT_HELP = 1,
@@ -411,7 +411,5 @@ int index_main(int argc, char** argv)
         read_db.clean();
 
     }
-
-
     return 0;
 }

--- a/src/nanopolish_index.cpp
+++ b/src/nanopolish_index.cpp
@@ -17,7 +17,7 @@
 #include <fstream>
 #include <sstream>
 #include <getopt.h>
-
+#include <slow5/slow5.h>
 #include <fast5.hpp>
 #include "nanopolish_index.h"
 #include "nanopolish_common.h"
@@ -40,6 +40,8 @@ static const char *INDEX_USAGE_MESSAGE =
 "      --help                           display this help and exit\n"
 "      --version                        display version\n"
 "  -v, --verbose                        display verbose output\n"
+" -t INT                                number of threads used for bgzf compression (makes indexing faster)\n"
+"      --slow5 FILE                     slow5 file\n"
 "  -d, --directory                      path to the directory containing the raw ONT signal files. This option can be given multiple times.\n"
 "  -s, --sequencing-summary             the sequencing summary file from albacore, providing this option will make indexing much faster\n"
 "  -f, --summary-fofn                   file containing the paths to the sequencing summary files (one per line)\n"
@@ -52,6 +54,8 @@ namespace opt
     static std::string reads_file;
     static std::vector<std::string> sequencing_summary_files;
     static std::string sequencing_summary_fofn;
+    static int threads = 1;
+    static char *slow5file = NULL;
 }
 static std::ostream* os_p;
 
@@ -208,7 +212,7 @@ void parse_sequencing_summary(const std::string& filename, std::multimap<std::st
     }
 }
 
-static const char* shortopts = "vd:f:s:";
+static const char* shortopts = "vd:f:s:t:";
 
 enum {
     OPT_HELP = 1,
@@ -217,21 +221,24 @@ enum {
 };
 
 static const struct option longopts[] = {
-    { "help",                      no_argument,       NULL, OPT_HELP },
-    { "version",                   no_argument,       NULL, OPT_VERSION },
-    { "log-level",                 required_argument, NULL, OPT_LOG_LEVEL },
-    { "verbose",                   no_argument,       NULL, 'v' },
-    { "directory",                 required_argument, NULL, 'd' },
-    { "sequencing-summary-file",   required_argument, NULL, 's' },
-    { "summary-fofn",              required_argument, NULL, 'f' },
+    { "help",                      no_argument,       NULL, OPT_HELP }, //0
+    { "version",                   no_argument,       NULL, OPT_VERSION }, //1
+    { "log-level",                 required_argument, NULL, OPT_LOG_LEVEL }, //2
+    { "verbose",                   no_argument,       NULL, 'v' }, //3
+    { "directory",                 required_argument, NULL, 'd' }, //4
+    { "sequencing-summary-file",   required_argument, NULL, 's' }, //5
+    { "summary-fofn",              required_argument, NULL, 'f' }, //6
+    { "threads",                   required_argument, NULL, 't'}, //7
+    { "slow5",                     required_argument, NULL, 0}, //8
     { NULL, 0, NULL, 0 }
 };
 
 void parse_index_options(int argc, char** argv)
 {
     bool die = false;
+    int longindex = 0;
     std::vector< std::string> log_level;
-    for (char c; (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
+    for (char c; (c = getopt_long(argc, argv, shortopts, longopts, &longindex)) != -1;) {
         std::istringstream arg(optarg != NULL ? optarg : "");
         switch (c) {
             case OPT_HELP:
@@ -247,6 +254,18 @@ void parse_index_options(int argc, char** argv)
             case 's': opt::sequencing_summary_files.push_back(arg.str()); break;
             case 'd': opt::raw_file_directories.push_back(arg.str()); break;
             case 'f': arg >> opt::sequencing_summary_fofn; break;
+            case 't':
+                arg >> opt::threads;
+                if (opt::threads < 1) {
+                    fprintf(stderr, "Number of threads should be larger than 0. You entered %d\n", opt::threads);
+                    exit(EXIT_FAILURE);
+                }
+                break;
+            case  0 :
+                if (longindex == 8) {
+                    opt::slow5file = optarg;
+                }
+                break;
         }
     }
 
@@ -269,6 +288,18 @@ void parse_index_options(int argc, char** argv)
     {
         std::cout << "\n" << INDEX_USAGE_MESSAGE;
         exit(EXIT_FAILURE);
+    }
+
+    if(opt::slow5file){
+        if (!opt::sequencing_summary_fofn.empty()) {
+            std::cerr << "Option --summary-fofn will be ignored in slow5 mode\n";
+        }
+        if (!opt::sequencing_summary_files.empty()) {
+            std::cerr << "Option --sequencing-summary-file will be ignored in slow5 mode\n";
+        }
+        if (!opt::raw_file_directories.empty()) {
+            std::cerr << "Option -d will be ignored in slow5 mode\n";
+        }
     }
 
     opt::reads_file = argv[optind++];
@@ -326,44 +357,71 @@ int index_main(int argc, char** argv)
 {
     parse_index_options(argc, argv);
 
-    // Read a map from fast5 files to read name from the sequencing summary files (if any)
-    process_summary_fofn();
-    std::multimap<std::string, std::string> fast5_to_read_name_map;
-    for(const auto& ss_filename : opt::sequencing_summary_files) {
-        if(opt::verbose > 2) {
-            fprintf(stderr, "summary: %s\n", ss_filename.c_str());
+    if(opt::slow5file == NULL){
+        // Read a map from fast5 files to read name from the sequencing summary files (if any)
+        process_summary_fofn();
+        std::multimap<std::string, std::string> fast5_to_read_name_map;
+        for(const auto& ss_filename : opt::sequencing_summary_files) {
+            if(opt::verbose > 2) {
+                fprintf(stderr, "summary: %s\n", ss_filename.c_str());
+            }
+            parse_sequencing_summary(ss_filename, fast5_to_read_name_map);
         }
-        parse_sequencing_summary(ss_filename, fast5_to_read_name_map);
-    }
 
-    // Detect non-unique fast5 file names in the summary file
-    // This occurs when a file with the same name (abc_0.fast5) appears in both fast5_pass
-    // and fast5_fail. This will be fixed by ONT but in the meantime we check for
-    // fast5 files that have a non-standard number of reads (>4000) and remove them
-    // from the map. These fast5s will be indexed the slow way.
-    clean_fast5_map(fast5_to_read_name_map);
+        // Detect non-unique fast5 file names in the summary file
+        // This occurs when a file with the same name (abc_0.fast5) appears in both fast5_pass
+        // and fast5_fail. This will be fixed by ONT but in the meantime we check for
+        // fast5 files that have a non-standard number of reads (>4000) and remove them
+        // from the map. These fast5s will be indexed the slow way.
+        clean_fast5_map(fast5_to_read_name_map);
 
-    // import read names, and possibly fast5 paths, from the fasta/fastq file
-    ReadDB read_db;
-    read_db.build(opt::reads_file);
-    bool all_reads_have_paths = read_db.check_signal_paths();
+        // import read names, and possibly fast5 paths, from the fasta/fastq file
+        ReadDB read_db;
+        read_db.build(opt::reads_file, opt::threads);
+        bool all_reads_have_paths = read_db.check_signal_paths();
 
-    // if the input fastq did not contain a complete set of paths
-    // use the fofn/directory provided to augment the index
-    if(!all_reads_have_paths) {
+        // if the input fastq did not contain a complete set of paths
+        // use the fofn/directory provided to augment the index
+        if(!all_reads_have_paths) {
 
-        for(const auto& dir_name : opt::raw_file_directories) {
-            index_path(read_db, dir_name, fast5_to_read_name_map);
+            for(const auto& dir_name : opt::raw_file_directories) {
+                index_path(read_db, dir_name, fast5_to_read_name_map);
+            }
+        }
+
+        size_t num_with_path = read_db.get_num_reads_with_path();
+        size_t num_reads = read_db.get_num_reads();
+        if(num_with_path == 0) {
+            fprintf(stderr,"No fast5 files found\n");
+            exit(EXIT_FAILURE);
+        } else {
+            read_db.print_stats();
+            read_db.save();
+            if (num_with_path < num_reads * 0.99 ) {
+                fprintf(stderr,"fast5 files could not be located for %ld reads\n",num_reads-num_with_path);
+            }
         }
     }
+    else{
+        slow5_file_t *sp = slow5_open(opt::slow5file,"r");
+        if(sp==NULL){
+            fprintf(stderr,"Error in opening slowfile %s\n",opt::slow5file);
+            exit(EXIT_FAILURE);
+        }
+        int ret=0;
+        ret = slow5_idx_create(sp);
+        if(ret<0){
+            fprintf(stderr,"Error in creating index for slow5 file %s\n",opt::slow5file);
+            exit(EXIT_FAILURE);
+        }
+        slow5_close(sp);
 
-    size_t num_with_path = read_db.get_num_reads_with_path();
-    if(num_with_path == 0) {
-        fprintf(stderr, "Error: no fast5 files found\n");
-        exit(EXIT_FAILURE);
-    } else {
-        read_db.print_stats();
-        read_db.save();
+        ReadDB read_db;
+        read_db.build(opt::reads_file, opt::threads);
+        read_db.clean();
+
     }
+
+
     return 0;
 }

--- a/src/nanopolish_read_db.cpp
+++ b/src/nanopolish_read_db.cpp
@@ -31,7 +31,7 @@ ReadDB::ReadDB() : m_fai(NULL)
 }
 
 //
-void ReadDB::build(const std::string &input_reads_filename)
+void ReadDB::build(const std::string& input_reads_filename)
 {
     // generate output filename
     m_indexed_reads_filename = input_reads_filename + GZIPPED_READS_SUFFIX;

--- a/src/nanopolish_read_db.cpp
+++ b/src/nanopolish_read_db.cpp
@@ -31,14 +31,14 @@ ReadDB::ReadDB() : m_fai(NULL)
 }
 
 //
-void ReadDB::build(const std::string& input_reads_filename, int threads)
+void ReadDB::build(const std::string &input_reads_filename)
 {
     // generate output filename
     m_indexed_reads_filename = input_reads_filename + GZIPPED_READS_SUFFIX;
 
     // Populate database with read names and convert the fastq
     // input into fasta for faidx
-    import_reads(input_reads_filename, m_indexed_reads_filename, threads);
+    import_reads(input_reads_filename, m_indexed_reads_filename);
 
     // build faidx
     int ret = fai_build(m_indexed_reads_filename.c_str());
@@ -106,7 +106,7 @@ ReadDB::~ReadDB()
 }
 
 //
-void ReadDB::import_reads(const std::string& input_filename, const std::string& out_fasta_filename, int threads)
+void ReadDB::import_reads(const std::string& input_filename, const std::string& out_fasta_filename)
 {
     if(is_directory(input_filename)) {
         fprintf(stderr, "error: %s is a directory, not a FASTA/FASTQ file\n", input_filename.c_str());

--- a/src/nanopolish_read_db.cpp
+++ b/src/nanopolish_read_db.cpp
@@ -139,13 +139,6 @@ void ReadDB::import_reads(const std::string& input_filename, const std::string& 
         exit(EXIT_FAILURE);
     }
 
-    if(threads>1){
-        int mt_status = bgzf_mt(bgzf_write_fp, threads, 64);
-        if(mt_status!=0){
-            fprintf(stderr,"Setting bgzf multi-threading failed. Proceeding with a single thread.");
-        }
-    }
-
     // read input sequences, add to DB and convert to fasta
     int ret = 0;
     kseq_t* seq = kseq_init(gz_read_fp);

--- a/src/nanopolish_read_db.h
+++ b/src/nanopolish_read_db.h
@@ -12,6 +12,7 @@
 #include <map>
 #include <vector>
 #include "htslib/faidx.h"
+#include <slow5/slow5.h>
 
 struct ReadDBData
 {
@@ -30,13 +31,16 @@ class ReadDB
         //
 
         //  construct the database from an input reads file
-        void build(const std::string& reads_filename);
+        void build(const std::string& reads_filename, int threads = 0);
 
         // save the database to disk
         void save() const;
 
+        // clean the database on disk for slow5 mode
+        void clean() const;
+
         // restore the database from disk
-        void load(const std::string& reads_filename);
+        void load(const std::string& reads_filename, int8_t slow_mode = 0);
 
         //
         // Data Access
@@ -47,7 +51,12 @@ class ReadDB
         
         // returns the path to the signal data for the given read
         std::string get_signal_path(const std::string& read_id) const;
-        
+
+        // useful when using slow5
+        void open_slow5_file(const std::string& path);
+        void close_slow5_file() const;
+        slow5_file_t* get_slow5_file() const;
+
         // returns true if a read with this ID is in the DB
         bool has_read(const std::string& read_id) const;
 
@@ -73,10 +82,13 @@ class ReadDB
         // print some summary stats about the database
         void print_stats() const;
 
+        int use_slow5_mode() const;
+
     private:
         
         //
-        void import_reads(const std::string& input_filename, const std::string& output_fasta_filename);
+        void import_reads(const std::string& input_filename,
+                          const std::string& output_fasta_filename, int threads);
 
         // the filename of the indexed data, after converting to fasta
         std::string m_indexed_reads_filename;
@@ -86,6 +98,8 @@ class ReadDB
 
         //
         faidx_t* m_fai;
+        int flag_use_slow5;
+        slow5_file_t* slow5_file; //useful when using slow5
 };
 
 #endif

--- a/src/nanopolish_read_db.h
+++ b/src/nanopolish_read_db.h
@@ -31,7 +31,7 @@ class ReadDB
         //
 
         //  construct the database from an input reads file
-        void build(const std::string &input_reads_filename);
+        void build(const std::string &reads_filename);
 
         // save the database to disk
         void save() const;
@@ -87,8 +87,7 @@ class ReadDB
     private:
         
         //
-        void import_reads(const std::string& input_filename,
-                          const std::string& output_fasta_filename);
+        void import_reads(const std::string& input_filename, const std::string& output_fasta_filename);
 
         // the filename of the indexed data, after converting to fasta
         std::string m_indexed_reads_filename;

--- a/src/nanopolish_read_db.h
+++ b/src/nanopolish_read_db.h
@@ -31,7 +31,7 @@ class ReadDB
         //
 
         //  construct the database from an input reads file
-        void build(const std::string& reads_filename, int threads = 0);
+        void build(const std::string &input_reads_filename);
 
         // save the database to disk
         void save() const;
@@ -88,7 +88,7 @@ class ReadDB
         
         //
         void import_reads(const std::string& input_filename,
-                          const std::string& output_fasta_filename, int threads);
+                          const std::string& output_fasta_filename);
 
         // the filename of the indexed data, after converting to fasta
         std::string m_indexed_reads_filename;

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -141,8 +141,8 @@ SquiggleRead::SquiggleRead(const std::string& name, const ReadDB& read_db, const
         }
         data = Fast5Loader::load_read(fast5_path, name);
         if(!data.is_valid) {
-            g_bad_fast5_file += 1;
             fprintf(stderr, "[warning] fast5 file is unreadable and will be skipped: %s\n", fast5_path.c_str());
+            g_bad_fast5_file += 1;
         }
     }
     if(data.is_valid) {

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -80,13 +80,16 @@ SquiggleRead::SquiggleRead(const std::string& name, const ReadDB& read_db, const
         slow5_file_t * slow5_file = read_db.get_slow5_file();
         if(!slow5_file){
             fprintf(stderr, "slow5 file is missing");
+            exit(EXIT_FAILURE);
         }
         if (!slow5_file->index) {
             fprintf(stderr,"No slow5 index has been loaded\n");
+            exit(EXIT_FAILURE);
         }
         int ret = slow5_get(name.c_str(), &rec, slow5_file);
         if(ret < 0){
             fprintf(stderr,"Error in when fetching the read\n");
+            exit(EXIT_FAILURE);
         }
 
         data.rt.n = rec->len_raw_signal;
@@ -97,8 +100,15 @@ SquiggleRead::SquiggleRead(const std::string& name, const ReadDB& read_db, const
 
         int err;
         char *cid = slow5_aux_get_string(rec, "channel_number", NULL, &err);
-        data.channel_params.channel_id = atoi(cid);
+        if(err < 0){
+            fprintf(stderr,"[warning] Error in when fetching the channel_number\n");
+        }else{
+            data.channel_params.channel_id = atoi(cid);
+        }
         data.start_time = slow5_aux_get_uint64(rec, "start_time", &err);
+        if(err < 0){
+            fprintf(stderr,"[warning] Error in when fetching the start_time\n");
+        }
         data.read_name = name;
         // metadata
         char* sequencing_kit = slow5_hdr_get("sequencing_kit", 0, slow5_file->header);

--- a/src/nanopolish_squiggle_read.cpp
+++ b/src/nanopolish_squiggle_read.cpp
@@ -111,8 +111,14 @@ SquiggleRead::SquiggleRead(const std::string& name, const ReadDB& read_db, const
         float* rawptr = (float*)calloc(rec->len_raw_signal, sizeof(float));
         raw_table rawtbl = { 0, 0, 0, NULL };
         data.rt = (raw_table) { rec->len_raw_signal, 0, rec->len_raw_signal, rawptr };
-        for (size_t i = 0; i < rec->len_raw_signal; i++) {
-            rawptr[i] = (((rec->raw_signal[i])+(rec->offset))*((rec->range)/(rec->digitisation)));
+        hsize_t nsample = rec->len_raw_signal;
+        float digitisation = rec->digitisation;
+        float offset = rec->offset;
+        float range = rec->range;
+        float raw_unit = range / digitisation;
+        for (size_t i = 0; i < nsample; i++) {
+            float signal = rec->raw_signal[i];
+            rawptr[i] = (signal + offset) * raw_unit;
         }
         slow5_rec_free(rec);
         data.is_valid = true;
@@ -135,7 +141,6 @@ SquiggleRead::SquiggleRead(const std::string& name, const ReadDB& read_db, const
     if(!this->events[0].empty()) {
         assert(this->base_model[0] != NULL);
     }
-
     free(data.rt.raw);
     data.rt.raw = NULL;
 }


### PR DESCRIPTION
Hey Jared,

I integrated slow5 (an alternative and a fast5 file format to replace fast5) as an input option. At the moment it is only implemented in nanopolish index and call-methylation. A quick benchmark using call-methylation produced the following results.

```
using a blow5(binary format of slow5) - 30 minutes
using fast5 files - 2 hours.
```

Here, slow5 wins by a big margin and I am sure that you would consider adding this to nanopolish. Please let me know what you think of the code implementation. I am happy to change it and most of the code is taken from F5C slow5 integration.
